### PR TITLE
Fixed issue with objects as value in java.util.properties

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -138,12 +138,12 @@ private[snowflake] class JDBCWrapper {
 
     // Always set CLIENT_SESSION_KEEP_ALIVE.
     // Note, can be overridden with options
-    jdbcProperties.put("client_session_keep_alive", new java.lang.Boolean(true))
+    jdbcProperties.put("client_session_keep_alive", "true")
 
     // Add extra properties from sfOptions
     val extraOptions = params.sfExtraOptions
     for ((k: String, v: Object) <- extraOptions) {
-      jdbcProperties.put(k.toLowerCase, v)
+      jdbcProperties.put(k.toLowerCase, v.toString())
     }
 
     // Set info on the system level


### PR DESCRIPTION
java.util.Properties().getProperty returns null when the value is an object other than String. This is resulting in a runtime exception when SparkSnowflake is used in an application where other JDBC drivers co-exist.
We are facing the issue with Postgres driver which in the connect method tries to read the properties using getProperty method.
https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/Driver.java#L221
