### PR TITLE
Double quoting columns create sql

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -182,7 +182,7 @@ private[snowflake] class JDBCWrapper {
     schema.fields.foreach { field =>
       {
         val name = field.name
-       
+        val formattedName = if (isQuoted(name)) name else quotedName(name)
         val typ: String = field.dataType match {
           case IntegerType => "INTEGER"
           case LongType => "INTEGER"
@@ -205,7 +205,7 @@ private[snowflake] class JDBCWrapper {
             throw new IllegalArgumentException(s"Don't know how to save $field of type ${field.name} to Snowflake")
         }
         val nullable = if (field.nullable) "" else "NOT NULL"
-        sb.append(s""", ${if (isQuoted(name)) name else quotedName(name)} $typ $nullable""".trim)
+        sb.append(s""", ${formattedName.replace("\"", "\\\"")} $typ $nullable""".trim)
       }
     }
     if (sb.length < 2) "" else sb.substring(2)
@@ -215,10 +215,12 @@ private[snowflake] class JDBCWrapper {
     name.startsWith("\"") && name.endsWith("\"") 
   }
   private def quotedName(name: String): String = {
-      if (name.matches("[_A-Z]([_0-9A-Z])*"))
+    // Name legality check going from spark => SF. 
+    // If the input identifier is legal, uppercase before wrapping it with double quotes.
+      if (name.matches("[_a-zA-Z]([_0-9a-zA-Z])*"))
         "\"" + name.toUpperCase + "\""
       else
-        name
+        "\"" + name + "\""
   }
 
   /**

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -182,7 +182,7 @@ private[snowflake] class JDBCWrapper {
     schema.fields.foreach { field =>
       {
         val name = field.name
-        val quotedName = if (isQuoted(name)) name else "\"" + name + "\""
+       
         val typ: String = field.dataType match {
           case IntegerType => "INTEGER"
           case LongType => "INTEGER"
@@ -205,7 +205,7 @@ private[snowflake] class JDBCWrapper {
             throw new IllegalArgumentException(s"Don't know how to save $field of type ${field.name} to Snowflake")
         }
         val nullable = if (field.nullable) "" else "NOT NULL"
-        sb.append(s""", $quotedName $typ $nullable""".trim)
+        sb.append(s""", ${if (isQuoted(name)) name else quotedName(name)} $typ $nullable""".trim)
       }
     }
     if (sb.length < 2) "" else sb.substring(2)
@@ -213,6 +213,12 @@ private[snowflake] class JDBCWrapper {
 
   private def isQuoted(name: String): Boolean = {
     name.startsWith("\"") && name.endsWith("\"") 
+  }
+  private def quotedName(name: String): String = {
+      if (name.matches("[_A-Z]([_0-9A-Z])*"))
+        "\"" + name.toUpperCase + "\""
+      else
+        name
   }
 
   /**

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -182,6 +182,7 @@ private[snowflake] class JDBCWrapper {
     schema.fields.foreach { field =>
       {
         val name = field.name
+        name = if (isQuoted(name)) name else "\"" + name.toUpperCase + "\""
         val typ: String = field.dataType match {
           case IntegerType => "INTEGER"
           case LongType => "INTEGER"
@@ -208,6 +209,10 @@ private[snowflake] class JDBCWrapper {
       }
     }
     if (sb.length < 2) "" else sb.substring(2)
+  }
+
+  private def isQuoted(name: String): Boolean = {
+    name.startsWith("\"") && name.endsWith("\"") 
   }
 
   /**

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -182,7 +182,7 @@ private[snowflake] class JDBCWrapper {
     schema.fields.foreach { field =>
       {
         val name = field.name
-        name = if (isQuoted(name)) name else "\"" + name.toUpperCase + "\""
+        val quotedName = if (isQuoted(name)) name else "\"" + name + "\""
         val typ: String = field.dataType match {
           case IntegerType => "INTEGER"
           case LongType => "INTEGER"
@@ -205,7 +205,7 @@ private[snowflake] class JDBCWrapper {
             throw new IllegalArgumentException(s"Don't know how to save $field of type ${field.name} to Snowflake")
         }
         val nullable = if (field.nullable) "" else "NOT NULL"
-        sb.append(s""", ${name.replace("\"", "\\\"")} $typ $nullable""".trim)
+        sb.append(s""", $quotedName $typ $nullable""".trim)
       }
     }
     if (sb.length < 2) "" else sb.substring(2)

--- a/src/test/scala/net/snowflake/spark/snowflake/SnowflakeSourceSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/SnowflakeSourceSuite.scala
@@ -321,9 +321,22 @@ class SnowflakeSourceSuite extends BaseTest {
     val createTableCommand =
       DefaultSnowflakeWriter.createTableSql(df, MergedParameters.apply(defaultParams)).trim
     val expectedCreateTableCommand =
-      """CREATE TABLE IF NOT EXISTS test_table (long_str VARCHAR(512),""" +
-        """ short_str VARCHAR(10), default_str STRING)"""
+      """CREATE TABLE IF NOT EXISTS test_table (\"LONG_STR\" VARCHAR(512),""" +
+        """ \"SHORT_STR\" VARCHAR(10), \"DEFAULT_STR\" STRING)"""
     assert(createTableCommand === expectedCreateTableCommand)
+  }
+
+    test("ensuring explictly quoted inputs are not uppercased") {
+      val schema = StructType(
+        StructField("default_str", StringType) ::
+        StructField("\"quoted_str\"", StringType) ::
+        Nil)
+      val df = testSqlContext.createDataFrame(sc.emptyRDD[Row], schema)
+      val createTableCommand =
+        DefaultSnowflakeWriter.createTableSql(df, MergedParameters.apply(defaultParams)).trim
+      val expectedCreateTableCommand =
+        """CREATE TABLE IF NOT EXISTS test_table (\"DEFAULT_STR\" STRING, \"quoted_str\" STRING)"""
+      assert(createTableCommand === expectedCreateTableCommand)
   }
 
   test("Respect SaveMode.ErrorIfExists when table exists") {

--- a/src/test/scala/net/snowflake/spark/snowflake/SnowflakeSourceSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/SnowflakeSourceSuite.scala
@@ -321,8 +321,22 @@ class SnowflakeSourceSuite extends BaseTest {
     val createTableCommand =
       DefaultSnowflakeWriter.createTableSql(df, MergedParameters.apply(defaultParams)).trim
     val expectedCreateTableCommand =
-      """CREATE TABLE IF NOT EXISTS test_table (long_str VARCHAR(512),""" +
-        """ short_str VARCHAR(10), default_str STRING)"""
+      """CREATE TABLE IF NOT EXISTS test_table ("long_str" VARCHAR(512),""" +
+        """ "short_str" VARCHAR(10), "default_str" STRING)"""
+    assert(createTableCommand === expectedCreateTableCommand)
+  }
+
+    test("ensuring default double quoting on columns") {
+    val schema = StructType(
+      StructField("test_str", StringType) ::
+      StructField("test_str_2", StringType) ::
+      Nil)
+    val df = testSqlContext.createDataFrame(sc.emptyRDD[Row], schema)
+    val createTableCommand =
+      DefaultSnowflakeWriter.createTableSql(df, MergedParameters.apply(defaultParams)).trim
+    val expectedCreateTableCommand =
+      """CREATE TABLE IF NOT EXISTS test_table ("test_str" STRING,""" +
+        """ "test_str_2" STRING)""" 
     assert(createTableCommand === expectedCreateTableCommand)
   }
 

--- a/src/test/scala/net/snowflake/spark/snowflake/SnowflakeSourceSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/SnowflakeSourceSuite.scala
@@ -321,22 +321,8 @@ class SnowflakeSourceSuite extends BaseTest {
     val createTableCommand =
       DefaultSnowflakeWriter.createTableSql(df, MergedParameters.apply(defaultParams)).trim
     val expectedCreateTableCommand =
-      """CREATE TABLE IF NOT EXISTS test_table ("long_str" VARCHAR(512),""" +
-        """ "short_str" VARCHAR(10), "default_str" STRING)"""
-    assert(createTableCommand === expectedCreateTableCommand)
-  }
-
-    test("ensuring default double quoting on columns") {
-    val schema = StructType(
-      StructField("test_str", StringType) ::
-      StructField("test_str_2", StringType) ::
-      Nil)
-    val df = testSqlContext.createDataFrame(sc.emptyRDD[Row], schema)
-    val createTableCommand =
-      DefaultSnowflakeWriter.createTableSql(df, MergedParameters.apply(defaultParams)).trim
-    val expectedCreateTableCommand =
-      """CREATE TABLE IF NOT EXISTS test_table ("test_str" STRING,""" +
-        """ "test_str_2" STRING)""" 
+      """CREATE TABLE IF NOT EXISTS test_table (long_str VARCHAR(512),""" +
+        """ short_str VARCHAR(10), default_str STRING)"""
     assert(createTableCommand === expectedCreateTableCommand)
   }
 


### PR DESCRIPTION
PR regarding issue #12 

calling dataframe.write() to a table that does not exist yet results in:

```
CREATE TABLE IF NOT EXISTS test_schema.test_table (id INTEGER NOT NULL, created_at TIMESTAMP, updated_at TIMESTAMP, name STRING NOT NULL, order INTEGER)
```
which fails with:

```
SQL compilation error: syntax error line 1 at position 138 unexpected ''order''.
```
whereas:

```
CREATE TABLE IF NOT EXISTS test_schema.test_table (id INTEGER NOT NULL, created_at TIMESTAMP, updated_at TIMESTAMP, name STRING NOT NULL, "order" INTEGER)
```
succeeds.

In the JDBCWrapper class, modified the schemaString method so that column names are always double-quoted in the createTableSql method in the SnowflakeWriter class. 

Added in a test case inside SnowflakeSourceSuite, which might be redundant with a modified, pre-existing test case.