### PR TITLE
Prevent NullPointerException from swallowing root cause on SnowflakeWrite

### DIFF
--- a/src/main/java/net/snowflake/spark/snowflake/s3upload/ExecutorServiceResultsHandler.java
+++ b/src/main/java/net/snowflake/spark/snowflake/s3upload/ExecutorServiceResultsHandler.java
@@ -84,6 +84,7 @@ public class ExecutorServiceResultsHandler<V> implements Iterable<V> {
             executorService.shutdownNow();
         }
         executorService = null;
+        completionService = null;
     }
 
     /**

--- a/src/main/java/net/snowflake/spark/snowflake/s3upload/ExecutorServiceResultsHandler.java
+++ b/src/main/java/net/snowflake/spark/snowflake/s3upload/ExecutorServiceResultsHandler.java
@@ -84,7 +84,6 @@ public class ExecutorServiceResultsHandler<V> implements Iterable<V> {
             executorService.shutdownNow();
         }
         executorService = null;
-        completionService = null;
     }
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
@@ -524,13 +524,11 @@ private[snowflake] class SnowflakeWriter(
 
           SnowflakeConnectorUtils.log.debug(
             "Completed S3 upload for partition.")
-
+          streamManager.complete()
         } catch {
           case ex: Exception =>
             streamManager.abort()
             SnowflakeConnectorUtils.handleS3Exception(ex)
-        } finally {
-          streamManager.complete()
         }
       })
 


### PR DESCRIPTION
An exception in writing to S3 can result in the following stack trace.  When an exception is thrown in `SnowflakeWriter.unloadData` the StreamTransferManager was aborted and then completed.  Because an abort nulls the ExecutorCompletorService, the call to `complete` will always throw a `NullPointerException`.  To prevent a `NullPointerException`, only call `complete` on successful unload and `abort`
on unsuccessful unload.

```
java.lang.RuntimeException: java.lang.NullPointerException
    at net.snowflake.spark.snowflake.s3upload.StreamTransferManager.complete(StreamTransferManager.java:223)
    at net.snowflake.spark.snowflake.SnowflakeWriter$$anonfun$unloadData$4.apply(SnowflakeWriter.scala:480)
    at net.snowflake.spark.snowflake.SnowflakeWriter$$anonfun$unloadData$4.apply(SnowflakeWriter.scala:415)
    at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$29.apply(RDD.scala:926)
    at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$29.apply(RDD.scala:926)
    at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2069)
    at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2069)
    at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
    at org.apache.spark.scheduler.Task.run(Task.scala:108)
    at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:338)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
    at net.snowflake.spark.snowflake.s3upload.ExecutorServiceResultsHandler$1.next(ExecutorServiceResultsHandler.java:69)
    at net.snowflake.spark.snowflake.s3upload.ExecutorServiceResultsHandler.awaitCompletion(ExecutorServiceResultsHandler.java:94)
    at net.snowflake.spark.snowflake.s3upload.StreamTransferManager.complete(StreamTransferManager.java:204)
    ... 12 more
```