### PR TITLE
Do not double-quote strings that are already quoted with backticks

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -403,7 +403,21 @@ object Utils {
     * check whether a name is quoted
     */
   def isQuoted(name: String): Boolean = {
+    isQuotedWithDoubleQuotes(name) || isQuotedWithBackticks(name)
+  }
+
+  /**
+    * check whether a name is quoted with double quotes
+    */
+  def isQuotedWithDoubleQuotes(name: String): Boolean = {
     name.startsWith("\"") && name.endsWith("\"")
+  }
+
+  /**
+    * check whether a name is quoted with backticks
+    */
+  def isQuotedWithBackticks(name: String): Boolean = {
+    name.startsWith("`") && name.endsWith("`")
   }
 
   /**

--- a/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
@@ -63,4 +63,10 @@ class UtilsSuite extends FunSuite with Matchers {
       removeCreds("s3n://ACCESSKEY:SECRETKEY@bucket/path/to/temp/dir") ===
       "s3n://bucket/path/to/temp/dir")
   }
+
+  test("ensureQuoted quotes identifiers correctly") {
+    Utils.ensureQuoted("identifier without quotes") shouldBe "\"identifier without quotes\""
+    Utils.ensureQuoted("\"identifier with quotes\"") shouldBe "\"identifier with quotes\""
+    Utils.ensureQuoted("`identifier with backticks`") shouldBe "`identifier with backticks`"
+  }
 }


### PR DESCRIPTION
Currently, the `columnmap` option forces column names to be wrapped
in double-quotes, even when the column name is already quoted with
backticks (e.g. the column name is a reserved word like `values`).

This commit accepts backtick-quoted strings as quoted when calling
`Utils.ensureQuoted()` or `Utils.isQuoted()`.

Note that I have not run the integration tests for my branch, but that
`build/sbt test` is green.