### PR TITLE
Fix exception when dealing with java.sql.Time

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -366,7 +366,7 @@ private[snowflake] class JDBCWrapper {
       case java.sql.Types.SMALLINT => IntegerType
       case java.sql.Types.SQLXML => StringType // Snowflake-todo: ?
       case java.sql.Types.STRUCT => StringType // Snowflake-todo: ?
-      //      case java.sql.Types.TIME          => TimestampType
+      case java.sql.Types.TIME => StringType
       case java.sql.Types.TIMESTAMP => TimestampType
       case java.sql.Types.TINYINT => IntegerType
       //      case java.sql.Types.VARBINARY     => BinaryType


### PR DESCRIPTION
Hi,

My org frequently queries data that's in the TIME format. Right now, it causes jobs to crash:
![Screen Shot 2019-03-19 at 5 37 08 PM](https://user-images.githubusercontent.com/1888108/54648230-d23a9c00-4a7b-11e9-8a4c-4f83d408d7fe.png)

This PR:
1) Casts java.sql.Time to String (preventing the crash from happening)
2) Cleans up build.sbt with modern sbt syntax

We could have chosen to convert java.sql.Time to Spark's TimestampType. However, this would cause a lot of confusion among analysts who would attempt to compare "real" timestamps to "java.sql.Time" timestamps (in which the date portion is zero'd out). That implicit conversion isn't intuitive so we're better off keeping it as a string and allowing analysts to explicitly convert.

Thanks!
