### PR TITLE
Register the snowflake data source

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+net.snowflake.spark.snowflake.DefaultSource

--- a/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
@@ -37,7 +37,10 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
   extends RelationProvider
     with SchemaRelationProvider
     with CreatableRelationProvider
-    with StreamSinkProvider{
+    with StreamSinkProvider
+    with DataSourceRegister {
+
+  override val shortName = "snowflake"
 
   private val log = LoggerFactory.getLogger(getClass)
 


### PR DESCRIPTION
If we register the Snowflake data source (see: https://spark.apache.org/docs/2.1.1/api/java/index.html?org/apache/spark/sql/sources/DataSourceRegister.html), we'll be able to look it up w/o having to pass the full package name.

So...
```
spark.read.format("snowflake")
```
instead of...
```
import net.snowflake.spark.snowflake.Utils
spark.read.format(Utils.SNOWFLAKE_SOURCE_NAME) //spark.read.format("net.snowflake.spark.snowflake")
```
similar to how the other formats are registered...
```
spark.read.format("csv")
spark.read.format("avro")
spark.read.format("parquet")
```
