### PR TITLE
Support new Telemetry API sendBatchAsyc() instead of sendBatch() from jdbc 3.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.9.6",
-      "net.snowflake" % "snowflake-jdbc" % "3.9.1",
+      "net.snowflake" % "snowflake-jdbc" % "3.10.0",
       "com.google.guava" % "guava" % "14.0.1" % Test,
       "org.scalatest" %% "scalatest" % "3.0.5" % Test,
       "org.mockito" % "mockito-core" % "1.10.19" % Test,

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
@@ -56,7 +56,7 @@ object SnowflakeTelemetry {
         telemetry.asInstanceOf[TelemetryClient].addLogToBatch(log,timestamp)
       }
     }
-    if(!telemetry.sendBatch()) logger.error("Telemetry is failed")
+    telemetry.sendBatchAsync()
   }
 
 


### PR DESCRIPTION
Support new Telemetry API sendBatchAsyc() instead of sendBatch() from jdbc 3.10.0