### PR TITLE
Check size of filesToUpload

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -55,9 +55,10 @@ private[io] object StageWriter {
 
       val filesToCopy = storage.upload(rdd, format, None, true)
 
-      writeToTable(conn, schema, saveMode, params,
-        filesToCopy.head.substring(0, filesToCopy.head.indexOf("/")), stage, format)
-
+      if (filesToCopy.size > 0) {
+        writeToTable(conn, schema, saveMode, params,
+          filesToCopy.head.substring(0, filesToCopy.head.indexOf("/")), stage, format)
+      }
     } finally {
       conn.close()
     }


### PR DESCRIPTION
Fixes errors generated when there are no files to copy: 

```
py4j.protocol.Py4JJavaError: An error occurred while calling o550.save.
: java.util.NoSuchElementException: head of empty list
	at scala.collection.immutable.Nil$.head(List.scala:431)
	at scala.collection.immutable.Nil$.head(List.scala:428)
	at net.snowflake.spark.snowflake.io.StageWriter$.writeToStage(StageWriter.scala:59)
```