### PR TITLE
Truncate and COPY INTO Target Table Transactionally

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -150,9 +150,9 @@ object Parameters {
     // Notes:
     // * tempdir, dbtable and url have no default and they *must* be provided
     "diststyle" -> "EVEN",
-    PARAM_USE_STAGING_TABLE -> "true",
+    PARAM_USE_STAGING_TABLE -> "false",
     PARAM_CONTINUE_ON_ERROR -> "off",
-    PARAM_TRUNCATE_TABLE -> "off",
+    PARAM_TRUNCATE_TABLE -> "on",
     PARAM_PREACTIONS -> "",
     PARAM_POSTACTIONS -> "",
     PARAM_AUTO_PUSHDOWN -> "on",

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -20,6 +20,8 @@ import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import net.snowflake.spark.snowflake._
 import net.snowflake.spark.snowflake.io.SupportedFormat.SupportedFormat
 import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
+import net.snowflake.spark.snowflake.io.StageWriter.log
+import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.SaveMode
@@ -27,9 +29,176 @@ import org.slf4j.LoggerFactory
 
 import scala.util.Random
 
+// Snowflake doesn't support DDL in tran, so the State Machine is
+// created to maintain the ATOMIC of write.
+// When writing to snowflake, there are at most 5 operations.
+// Operation 1: Drop table (Optional)
+//              "Drop table" is implemented as "rename table".
+//              In case of COMMIT, the renamed table is dropped.
+//              In case of Rollback, it is rename back.
+// Operation 2: Create table (Optional)
+//              In case of Rollback, drop the created table.
+// Operation 3: Truncate table (Optional)
+//              Truncate table and COPY INTO are put in one user transaction
+//              It is commit/rollback,
+// Operation 4: Copy-into (MUST)
+// Operation 5: commit or rollback (MUST)
+//              The rollback is done in reverse order of the happened operations.
+class WriteTableState(conn: Connection) {
+  // In case a table need to drop, rename is first. It will be dropped when commit.
+  private var tableNameToBeDropped: String = ""
+  private var tableNameToBeDroppedRename: String = ""
+  // The table name created by this write operation. It is dropped when rollback.
+  private var tableNameToBeCreated: String = ""
+  // The user transaction will cover TRUNCATE table and COPY-INTO
+  private var transactionName: String = ""
+
+  private def clearStatus(): Unit = {
+    tableNameToBeDropped = ""
+    tableNameToBeDroppedRename = ""
+    tableNameToBeCreated = ""
+    transactionName = ""
+  }
+
+  def dropTable(tableName: String): Unit = {
+    tableNameToBeDropped = tableName
+    tableNameToBeDroppedRename =
+      s"${tableName}_rename_${Math.abs(Random.nextInt()).toString}"
+    conn.renameTable(tableNameToBeDroppedRename, tableNameToBeDropped)
+
+    TestHook.raiseExceptionIfTestFlagEnabled(
+      TestHookFlag.TH_WRITE_ERROR_AFTER_DROP_OLD_TABLE,
+      "Negative test to raise error after dropping existing table"
+    )
+  }
+
+  def createTable(tableName: String, schema: StructType,
+                  params: MergedParameters): Unit = {
+    tableNameToBeCreated = tableName
+    conn.createTable(tableNameToBeCreated, schema, params,
+      overwrite = false, temporary = false)
+
+    TestHook.raiseExceptionIfTestFlagEnabled(
+      TestHookFlag.TH_WRITE_ERROR_AFTER_CREATE_NEW_TABLE,
+      "Negative test to raise error after create new table"
+    )
+  }
+
+  private def beginTranIfNotBeginYet(): Unit = {
+    if (transactionName.isEmpty) {
+      transactionName = s"spark_connector_tx_${Math.abs(Random.nextInt()).toString}"
+      // Start a user transaction
+      conn.createStatement().execute(s"START TRANSACTION NAME $transactionName")
+    }
+  }
+
+  def truncateTable(tableName: String): Unit = {
+    beginTranIfNotBeginYet()
+
+    conn.truncateTable(tableName)
+
+    TestHook.raiseExceptionIfTestFlagEnabled(
+      TestHookFlag.TH_WRITE_ERROR_AFTER_TRUNCATE_TABLE,
+      "Negative test to raise error after truncate table"
+    )
+  }
+
+  def copyIntoTable(schema: StructType,
+                    saveMode: SaveMode,
+                    params: MergedParameters,
+                    file: String,
+                    tempStage: String,
+                    format: SupportedFormat): Unit = {
+    val targetTable = params.table.get
+
+    beginTranIfNotBeginYet()
+
+    // pre actions
+    Utils.executePreActions(
+      DefaultJDBCWrapper,
+      conn,
+      params,
+      Option(targetTable)
+    )
+
+    // Load the temporary data into the new file
+    val copyStatement =
+      StageWriter.copySql(
+        schema,
+        saveMode,
+        params,
+        targetTable,
+        file,
+        tempStage,
+        format,
+        conn
+      )
+    // copy
+    log.debug(Utils.sanitizeQueryText(copyStatement.toString))
+    // todo: handle on_error parameter on spark side
+
+    // report the number of skipped files.
+    // todo: replace table name to Identifier(?) after bug fixed
+    val resultSet = copyStatement.execute(params.bindVariableEnabled)(conn)
+    if (params.continueOnError) {
+      var rowSkipped: Long = 0L
+      while (resultSet.next()) {
+        rowSkipped +=
+          resultSet.getLong("rows_parsed") -
+            resultSet.getLong("rows_loaded")
+      }
+      log.error(s"ON_ERROR: Continue -> Skipped $rowSkipped rows")
+    }
+    Utils.setLastCopyLoad(copyStatement.toString)
+    // post actions
+    Utils.executePostActions(
+      DefaultJDBCWrapper,
+      conn,
+      params,
+      Option(targetTable)
+    )
+
+    TestHook.raiseExceptionIfTestFlagEnabled(
+      TestHookFlag.TH_WRITE_ERROR_AFTER_COPY_INTO,
+      "Negative test to raise error after copy-into is executed"
+    )
+  }
+
+  def commit(): Unit = {
+    // Commit transaction
+    conn.commit()
+
+    // Actually drop the table if "rename table" is used instead of "drop table"
+    if (!tableNameToBeDroppedRename.isEmpty) {
+      conn.dropTable(tableNameToBeDroppedRename)
+    }
+
+    clearStatus()
+  }
+
+  def rollback(): Unit = {
+    // Rollback TRUNCATE_TABLE & COPY INTO
+    if (!transactionName.isEmpty) {
+      conn.rollback()
+    }
+
+    // Drop created table
+    if (!tableNameToBeCreated.isEmpty) {
+      conn.dropTable(tableNameToBeCreated)
+    }
+
+    // Rename back existing table
+    if (!tableNameToBeDroppedRename.isEmpty) {
+      conn.renameTable(tableNameToBeDropped, tableNameToBeDroppedRename)
+    }
+
+    clearStatus()
+  }
+}
+
 private[io] object StageWriter {
 
-  private val log = LoggerFactory.getLogger(getClass)
+  private[io] val log = LoggerFactory.getLogger(getClass)
 
   def writeToStage(rdd: RDD[String],
                    schema: StructType,
@@ -75,6 +244,69 @@ private[io] object StageWriter {
     * load data from stage to table
     */
   private def writeToTable(conn: Connection,
+                           schema: StructType,
+                           saveMode: SaveMode,
+                           params: MergedParameters,
+                           file: String,
+                           tempStage: String,
+                           format: SupportedFormat): Unit = {
+    if (params.useStagingTable) {
+      writeToTableWithStagingTable(conn, schema, saveMode, params, file, tempStage, format)
+    } else {
+      writeToTableWithoutStagingTable(conn, schema, saveMode, params, file, tempStage, format)
+    }
+  }
+
+  /**
+    * load data from stage to table without staging table
+    */
+  private def writeToTableWithoutStagingTable(conn: Connection,
+                                           schema: StructType,
+                                           saveMode: SaveMode,
+                                           params: MergedParameters,
+                                           file: String,
+                                           tempStage: String,
+                                           format: SupportedFormat): Unit = {
+    val tableName: String = params.table.get.name
+    val writeTableState = new WriteTableState(conn)
+
+    try {
+      // Drop table only if necessary.
+      if (saveMode == SaveMode.Overwrite &&
+        DefaultJDBCWrapper.tableExists(conn, tableName) &&
+        !params.truncateTable )
+      {
+        writeTableState.dropTable(tableName)
+      }
+
+      // If create table if table doesn't exist
+      if (!DefaultJDBCWrapper.tableExists(conn, tableName))
+      {
+        writeTableState.createTable(tableName, schema, params)
+      } else if (params.truncateTable && saveMode == SaveMode.Overwrite) {
+        writeTableState.truncateTable(tableName)
+      }
+
+      // Run COPY INTO and related commands
+      writeTableState.copyIntoTable(schema, saveMode, params, file, tempStage, format)
+
+      // Commit a user transaction
+      writeTableState.commit()
+    } catch {
+      case e: Exception =>
+        // Rollback all the changes
+        writeTableState.rollback()
+
+        log.error("Error occurred while loading files to Snowflake: " + e)
+        throw e
+    }
+  }
+
+  /**
+    * load data from stage to table with staging table
+    * This function is deprecated.
+    */
+  private def writeToTableWithStagingTable(conn: Connection,
                            schema: StructType,
                            saveMode: SaveMode,
                            params: MergedParameters,
@@ -185,7 +417,7 @@ private[io] object StageWriter {
   /**
     * Generate the COPY SQL command
     */
-  private def copySql(schema: StructType,
+  private[io] def copySql(schema: StructType,
                       saveMode: SaveMode,
                       params: MergedParameters,
                       table: TableName,


### PR DESCRIPTION
SNOW-110427
1. Change the default value of "usestagingtable" as "off", "truncate_table" as "on". So by default, when "Overwrite" Mode is used and table exists, the old table is not re-created any more.
2. Make "truncate table" and "copy into" in one transaction when "usestagingtable" is off.
3. Introduce TEST HOOK for negative test.