### PR TITLE
add authenticator=oauth support to Spark

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -96,7 +96,7 @@ object Parameters {
     "column_mismatch_behavior"
   )
 
-  // 2020-02-13 - add Oauth params
+  // Add Oauth params
   val PARAM_AUTHENTICATOR: String = knownParam("sfauthenticator")
   val PARAM_OAUTH_TOKEN: String = knownParam("sftoken")
 
@@ -531,7 +531,7 @@ object Parameters {
     }
 
     /**
-      *  2020-02-13 - mapping OAuth and authenticator values
+      *  Mapping OAuth and authenticator values
      */
     def sfAuthenticator: Option[String] = parameters.get(PARAM_AUTHENTICATOR)
     def sfToken: Option[String] = parameters.get(PARAM_OAUTH_TOKEN)

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -200,19 +200,19 @@ object Parameters {
         "A snowflake user must be provided with '" + PARAM_SF_USER + "' parameter, e.g. 'user1'"
       )
     }
-    val authenticatorVal = userParameters.get(PARAM_AUTHENTICATOR)
+    val tokenVal = userParameters.get(PARAM_OAUTH_TOKEN)
     if ((!userParameters.contains(PARAM_SF_PASSWORD)) &&
         (!userParameters.contains(PARAM_PEM_PRIVATE_KEY)) &&
         //  if OAuth token not provided
-        (!authenticatorVal.contains("oauth"))) {
+        (tokenVal.isEmpty)) {
       throw new IllegalArgumentException(
         "A snowflake password or private key path or OAuth token must be provided with '" +
-         PARAM_SF_PASSWORD + " or " + PARAM_PEM_PRIVATE_KEY + " or " +
+         PARAM_SF_PASSWORD + " or " + PARAM_PEM_PRIVATE_KEY + "' or '" +
          PARAM_OAUTH_TOKEN + "' parameter, e.g. 'password'"
       )
     }
-    val tokenVal = userParameters.get(PARAM_OAUTH_TOKEN)
     //  ensure OAuth token  provided if PARAM_AUTHENTICATOR = OAuth
+    val authenticatorVal = userParameters.get(PARAM_AUTHENTICATOR)
     if ((authenticatorVal.contains("oauth")) &&
         (tokenVal.isEmpty)) {
       throw new IllegalArgumentException(

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -169,9 +169,7 @@ object Parameters {
     PARAM_USE_COPY_UNLOAD -> "true",
     PARAM_USE_PROXY -> "false",
     PARAM_EXPECTED_PARTITION_COUNT -> "1000",
-    PARAM_MAX_RETRY_COUNT -> "10",
-    // 2020-02-13 Default authenticator
-    PARAM_AUTHENTICATOR -> "snowflake"
+    PARAM_MAX_RETRY_COUNT -> "10"
   )
 
   /**
@@ -202,29 +200,32 @@ object Parameters {
         "A snowflake user must be provided with '" + PARAM_SF_USER + "' parameter, e.g. 'user1'"
       )
     }
-    val authenticatorVal = userParameters.getOrElse(PARAM_AUTHENTICATOR, "")
+    val authenticatorVal = userParameters.get(PARAM_AUTHENTICATOR)
     if ((!userParameters.contains(PARAM_SF_PASSWORD)) &&
         (!userParameters.contains(PARAM_PEM_PRIVATE_KEY)) &&
-        // 2020-02-13 - if OAuth token not provided
-        (!authenticatorVal.equals("oauth"))) {
+        //  if OAuth token not provided
+        (!authenticatorVal.contains("oauth"))) {
       throw new IllegalArgumentException(
-        "A snowflake password or private key path must be provided with '" + PARAM_SF_PASSWORD +
-          " or " + PARAM_PEM_PRIVATE_KEY + " or " + PARAM_OAUTH_TOKEN + "' parameter, e.g. 'password'"
+        "A snowflake password or private key path or OAuth token must be provided with '" +
+         PARAM_SF_PASSWORD + " or " + PARAM_PEM_PRIVATE_KEY + " or " +
+         PARAM_OAUTH_TOKEN + "' parameter, e.g. 'password'"
       )
     }
-    // 2020-02-13 - ensure OAuth token  provided if PARAM_AUTHENTICATOR = OAuth
-    val tokenVal = userParameters.getOrElse(PARAM_OAUTH_TOKEN, "")
-    if ((authenticatorVal.equals("oauth")) &&
-        (tokenVal.isEmpty())) {
+    val tokenVal = userParameters.get(PARAM_OAUTH_TOKEN)
+    //  ensure OAuth token  provided if PARAM_AUTHENTICATOR = OAuth
+    if ((authenticatorVal.contains("oauth")) &&
+        (tokenVal.isEmpty)) {
       throw new IllegalArgumentException(
-        "An OAuth token is required if the authenticator mode is '" + PARAM_AUTHENTICATOR + "'"
+        "An OAuth token is required if the authenticator mode is '" +
+        PARAM_AUTHENTICATOR + "'"
       )
     }
-    // 2020-02-13 -  PARAM_AUTHENTICATOR must be OAuth if OAuth token is specified
-    if ((!authenticatorVal.equals("oauth")) &&
-        (!tokenVal.isEmpty())) {
+    //  PARAM_AUTHENTICATOR must be OAuth if OAuth token is specified
+    if (!(authenticatorVal.contains("oauth")) &&
+        (!tokenVal.isEmpty)) {
       throw new IllegalArgumentException(
-        "Invalid authenticator mode passed '" + PARAM_AUTHENTICATOR + ", the authentication mode must be 'oauth' when specifying an OAuth token"
+        "Invalid authenticator mode passed '" + PARAM_AUTHENTICATOR +
+        ", the authentication mode must be 'oauth' when specifying OAuth token"
       )
     }
     if (!userParameters.contains(PARAM_SF_DBTABLE) && !userParameters.contains(
@@ -532,7 +533,7 @@ object Parameters {
     /**
       *  2020-02-13 - mapping OAuth and authenticator values
      */
-    def sfAuthenticator: String = parameters.getOrElse(PARAM_AUTHENTICATOR, "snowflake")
+    def sfAuthenticator: Option[String] = parameters.get(PARAM_AUTHENTICATOR)
     def sfToken: Option[String] = parameters.get(PARAM_OAUTH_TOKEN)
 
     def expectedPartitionCount: Int = {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -146,7 +146,12 @@ private[snowflake] class JDBCWrapper {
       case Some(privateKey) =>
         jdbcProperties.put("privateKey", privateKey)
       case None =>
-        jdbcProperties.put("password", params.sfPassword)
+        // Adding OAuth Token parameter
+        params.sfToken match {
+          case Some(value) =>
+            jdbcProperties.put("token", value)
+          case None => jdbcProperties.put("password", params.sfPassword)
+        }
     }
     jdbcProperties.put("ssl", params.sfSSL) // Has a default
     // Optional properties
@@ -177,9 +182,12 @@ private[snowflake] class JDBCWrapper {
       case None =>
     }
 
-    // 2020-02-13 Adding Authenticator and Oauth tokens
-    jdbcProperties.put("authenticator", params.sfAuthenticator)
-    jdbcProperties.put("token", params.sfToken)
+    // Adding Authenticator parameter
+    params.sfAuthenticator match {
+      case Some(value) =>
+        jdbcProperties.put("authenticator", value)
+      case _ => // No default value for it.
+    }
 
     // Always set CLIENT_SESSION_KEEP_ALIVE.
     // Note, can be overridden with options

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -177,6 +177,10 @@ private[snowflake] class JDBCWrapper {
       case None =>
     }
 
+    // 2020-02-13 Adding Authenticator and Oauth tokens
+    jdbcProperties.put("authenticator", params.sfAuthenticator)
+    jdbcProperties.put("token", params.sfToken)
+
     // Always set CLIENT_SESSION_KEEP_ALIVE.
     // Note, can be overridden with options
     jdbcProperties.put("client_session_keep_alive", "true")

--- a/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
@@ -100,4 +100,39 @@ class ParametersSuite extends FunSuite with Matchers {
     val mergedParams = Parameters.mergeParameters(params.toMap)
     mergedParams.sfRole shouldBe Some("admin")
   }
+
+  // 2020-02-13 - add Authenticator and OAuth parameter tests
+
+  test("See if Authenticator parameter defaults to 'snowflake'") {
+    val params = collection.mutable.Map() ++= minParams
+    val mergedParams = Parameters.mergeParameters(params.toMap)
+    mergedParams.sfAuthenticator shouldBe "snowflake"
+  }
+
+  test("See if we can specify Authenticator/token") {
+    val params = collection.mutable.Map() ++= minParams
+    params += "sfauthenticator" -> "oauth"
+    params += "sftoken" -> "mytoken"
+    val mergedParams = Parameters.mergeParameters(params.toMap)
+    mergedParams.sfAuthenticator shouldBe "oauth"
+    mergedParams.sfToken shouldBe Some("mytoken")
+  }
+
+  test("Must specify OAuth Token when Authenticator mode equals 'oauth'") {
+    intercept[IllegalArgumentException] {
+      val params = collection.mutable.Map() ++= minParams
+      params += "sfauthenticator" -> "oauth"
+      params.remove("sftoken")
+      Parameters.mergeParameters(params.toMap)
+    }.getMessage should (include("token") and include("required") and include("authenticator")  )
+  }
+
+  test("Authenticator mode must be 'oauth' when an OAuth token is specified") {
+    intercept[IllegalArgumentException] {
+      val params = collection.mutable.Map() ++= minParams
+      params += "sftoken" -> "mytoken"
+      Parameters.mergeParameters(params.toMap)
+    }.getMessage should (include("token") and include("Invalid") and include("authenticator")  )
+  }
+
 }

--- a/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
@@ -101,20 +101,15 @@ class ParametersSuite extends FunSuite with Matchers {
     mergedParams.sfRole shouldBe Some("admin")
   }
 
-  // 2020-02-13 - add Authenticator and OAuth parameter tests
-
-  test("See if Authenticator parameter defaults to 'snowflake'") {
-    val params = collection.mutable.Map() ++= minParams
-    val mergedParams = Parameters.mergeParameters(params.toMap)
-    mergedParams.sfAuthenticator shouldBe "snowflake"
-  }
+  //  add Authenticator and OAuth parameter tests
 
   test("See if we can specify Authenticator/token") {
     val params = collection.mutable.Map() ++= minParams
     params += "sfauthenticator" -> "oauth"
     params += "sftoken" -> "mytoken"
+    params.remove("sfpassword")
     val mergedParams = Parameters.mergeParameters(params.toMap)
-    mergedParams.sfAuthenticator shouldBe "oauth"
+    mergedParams.sfAuthenticator shouldBe Some("oauth")
     mergedParams.sfToken shouldBe Some("mytoken")
   }
 
@@ -124,7 +119,8 @@ class ParametersSuite extends FunSuite with Matchers {
       params += "sfauthenticator" -> "oauth"
       params.remove("sftoken")
       Parameters.mergeParameters(params.toMap)
-    }.getMessage should (include("token") and include("required") and include("authenticator")  )
+    }.getMessage should (include("token") and include("required") and
+      include("authenticator")  )
   }
 
   test("Authenticator mode must be 'oauth' when an OAuth token is specified") {
@@ -132,7 +128,8 @@ class ParametersSuite extends FunSuite with Matchers {
       val params = collection.mutable.Map() ++= minParams
       params += "sftoken" -> "mytoken"
       Parameters.mergeParameters(params.toMap)
-    }.getMessage should (include("token") and include("Invalid") and include("authenticator")  )
+    }.getMessage should (include("token") and include("Invalid") and
+      include("authenticator")  )
   }
 
 }

--- a/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
@@ -127,6 +127,7 @@ class ParametersSuite extends FunSuite with Matchers {
     intercept[IllegalArgumentException] {
       val params = collection.mutable.Map() ++= minParams
       params += "sftoken" -> "mytoken"
+      params.remove("sfpassword")
       Parameters.mergeParameters(params.toMap)
     }.getMessage should (include("token") and include("Invalid") and
       include("authenticator")  )

--- a/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
@@ -101,7 +101,7 @@ class ParametersSuite extends FunSuite with Matchers {
     mergedParams.sfRole shouldBe Some("admin")
   }
 
-  //  add Authenticator and OAuth parameter tests
+  //  Add Authenticator and OAuth parameter tests
 
   test("See if we can specify Authenticator/token") {
     val params = collection.mutable.Map() ++= minParams


### PR DESCRIPTION
Adding OAuth authenticator mode and OAuth token parameters and passing to JDBC wrapper (see SNOW-120331)