### PR TITLE
Support dot(.) in column name

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/ColumnMappingIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/ColumnMappingIntegrationSuite.scala
@@ -22,6 +22,8 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
   val dbtable8 = s"column_mapping_test_8_$randomSuffix"
   val dbtable9 = s"column_mapping_test_9_$randomSuffix"
   val dbtable10 = s"column_mapping_test_10_$randomSuffix"
+  val dbtable11 = s"column_mapping_test_11_$randomSuffix"
+  val dbtable12 = s"column_mapping_test_12_$randomSuffix"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -53,6 +55,8 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       jdbcUpdate(s"drop table if exists $dbtable8")
       jdbcUpdate(s"drop table if exists $dbtable9")
       jdbcUpdate(s"drop table if exists $dbtable10")
+      jdbcUpdate(s"drop table if exists $dbtable11")
+      jdbcUpdate(s"drop table if exists $dbtable12")
     } finally {
       super.afterAll()
     }
@@ -451,4 +455,126 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
         .save()
     }
   }
+
+  test("Test column names with .(dot) for column_mapping") {
+    jdbcUpdate(s"drop table if exists $dbtable11")
+    val schema = StructType(List(
+      StructField("a.1", StringType),
+      StructField("B..1", IntegerType),
+      StructField("a1", IntegerType)
+    ))
+    val data: RDD[Row] = sc.makeRDD(List(Row("val", 4, 5)))
+    val df = sqlContext.createDataFrame(data, schema)
+
+    // Create table and write data with column_mapping = "order"
+    df.write.format("snowflake")
+      .options(connectorOptionsNoTable)
+      .option("dbtable", dbtable11)
+      .option("column_mapping", "order")
+      .mode(SaveMode.Append)
+      .save()
+
+    // Append data with column_mapping = "name"
+    df.write.format("snowflake")
+      .options(connectorOptionsNoTable)
+      .option("dbtable", dbtable11)
+      .option("column_mapping", "name")
+      .mode(SaveMode.Append)
+      .save()
+
+    // Read and verify data.
+    // Note: there are dot in the column name, so "keep_column_case = true" is necessary.
+    val resultDF = sparkSession.read.format("snowflake")
+      .options(connectorOptionsNoTable)
+      .option("keep_column_case", "true")
+      .option("dbtable", dbtable11)
+      .load().cache()
+
+    resultDF.show
+
+    // println(s"table name: $dbtable11")
+    // Note: the column name needs to be enclosed by `(backticks) if there is .(dot) in it.
+    var result = resultDF.select("`a.1`").collect().toSeq
+    assert(result(0)(0) == "val")
+    assert(result(1)(0) == "val")
+    result = resultDF.select("`A.1`").collect().toSeq
+    assert(result(0)(0) == "val")
+    assert(result(1)(0) == "val")
+
+    result = resultDF.select("`b..1`").collect().toSeq
+    assert(result(0)(0).toString == "4")
+    assert(result(1)(0).toString == "4")
+    result = resultDF.select("`B..1`").collect().toSeq
+    assert(result(0)(0).toString == "4")
+    assert(result(1)(0).toString == "4")
+
+    result = resultDF.select("a1").collect().toSeq
+    assert(result(0)(0).toString == "5")
+    assert(result(1)(0).toString == "5")
+    result = resultDF.select("A1").collect().toSeq
+    assert(result(0)(0).toString == "5")
+    assert(result(1)(0).toString == "5")
+  }
+
+  test("Test column names with .(dot) for columnmap") {
+    jdbcUpdate(s"drop table if exists $dbtable12")
+    val schema = StructType(List(
+      StructField("a.1", StringType),
+      StructField("B..1", StringType),
+      StructField("c1", StringType)
+    ))
+    val data: RDD[Row] = sc.makeRDD(List(Row("A", "B", "C")))
+    val df = sqlContext.createDataFrame(data, schema)
+
+    // Create table and write data with column_mapping = "order"
+    df.write.format("snowflake")
+      .options(connectorOptionsNoTable)
+      .option("dbtable", dbtable12)
+      .option("column_mapping", "order")
+      .mode(SaveMode.Append)
+      .save()
+
+    // Append data with columnnap = a -> b, b -> c, c-> a
+    val columnmap = Map("a.1" -> "B..1", "B..1" -> "c1", "c1" -> "a.1").toString()
+    df.write.format("snowflake")
+      .options(connectorOptionsNoTable)
+      .option("dbtable", dbtable12)
+      .option("columnmap", columnmap)
+      .mode(SaveMode.Append)
+      .save()
+
+    // Read and verify data.
+    // Note: there are dot in the column name, so "keep_column_case = true" is necessary.
+    val resultDF = sparkSession.read.format("snowflake")
+      .options(connectorOptionsNoTable)
+      .option("keep_column_case", "true")
+      .option("dbtable", dbtable12)
+      .load().cache()
+
+    resultDF.show
+
+    // println(s"table name: $dbtable12")
+    // Note: the column name needs to be enclosed by `(backticks) if there is .(dot) in it.
+    var result = resultDF.select("`a.1`").collect().toSeq
+    assert(result(0)(0) == "A")
+    assert(result(1)(0) == "C")
+    result = resultDF.select("`A.1`").collect().toSeq
+    assert(result(0)(0) == "A")
+    assert(result(1)(0) == "C")
+
+    result = resultDF.select("`B..1`").collect().toSeq
+    assert(result(0)(0) == "B")
+    assert(result(1)(0) == "A")
+    result = resultDF.select("`b..1`").collect().toSeq
+    assert(result(0)(0) == "B")
+    assert(result(1)(0) == "A")
+
+    result = resultDF.select("C1").collect().toSeq
+    assert(result(0)(0) == "C")
+    assert(result(1)(0) == "B")
+    result = resultDF.select("c1").collect().toSeq
+    assert(result(0)(0) == "C")
+    assert(result(1)(0) == "B")
+  }
+
 }

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
@@ -108,7 +108,13 @@ private[snowflake] class SnowflakeWriter(jdbcWrapper: JDBCWrapper) {
                                    params: MergedParameters): DataFrame =
     params.columnMap match {
       case Some(map) =>
-        val names = map.keys.toSeq
+        // Enclose column name with backtick(`) if dot(.) exists in column name
+        val names = map.keys.toSeq.map(name =>
+          if (name.contains(".")) {
+            s"`$name`"
+          } else {
+            name
+          })
         try {
           dataFrame.select(names.head, names.tail: _*)
         } catch {


### PR DESCRIPTION
In Spark, if there are dot(.) in the column name, the column name should be enclosed with backtick(`). Spark connector follow this rule. 
FYI.
https://forums.databricks.com/questions/30739/how-to-deal-with-column-name-with-dot-in-pyspark-d.html
SNOW-116375