### PR TITLE
Replace SQLContext with SparkSession in IT Test

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/ColumnMappingIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/ColumnMappingIntegrationSuite.scala
@@ -39,7 +39,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
         StructField("five", IntegerType)
       )
     )
-    df = sqlContext.createDataFrame(data, schema)
+    df = sparkSession.createDataFrame(data, schema)
   }
 
   override def afterAll(): Unit = {
@@ -63,7 +63,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
   }
 
   def checkTestTable(expectedAnswer: Seq[Row]): Unit = {
-    val loadedDf = sqlContext.read
+    val loadedDf = sparkSession.read
       .format(SNOWFLAKE_SOURCE_SHORT_NAME)
       .options(connectorOptionsNoTable)
       .option("query", s"select * from $dbtable order by ONE")
@@ -135,7 +135,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       List(StructField("str", StringType), StructField("NUM", IntegerType))
     )
     val data1: RDD[Row] = sc.makeRDD(List(Row("a", 1), Row("b", 2)))
-    val df1 = sqlContext.createDataFrame(data1, schema1)
+    val df1 = sparkSession.createDataFrame(data1, schema1)
 
     // error by default
     assertThrows[SnowflakeSQLException] {
@@ -178,7 +178,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       )
     )
     val data: RDD[Row] = sc.makeRDD(List(Row("a", true, 1), Row("b", false, 2)))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     // error by default
     assertThrows[UnsupportedOperationException] {
@@ -216,7 +216,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
     jdbcUpdate(s"create or replace table $dbtable3 (num int, str string)")
     val schema = StructType(List(StructField("str", StringType)))
     val data: RDD[Row] = sc.makeRDD(List(Row("a"), Row("b")))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     assertThrows[UnsupportedOperationException] {
       df.write
@@ -253,7 +253,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       List(StructField("str", StringType), StructField("useless", BooleanType))
     )
     val data: RDD[Row] = sc.makeRDD(List(Row("a", true), Row("b", false)))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     assertThrows[UnsupportedOperationException] {
       df.write
@@ -298,7 +298,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
         Row(new Date(System.currentTimeMillis()), 2)
       )
     )
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     df.write
       .format(SNOWFLAKE_SOURCE_SHORT_NAME)
@@ -323,7 +323,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
         Row(new Date(System.currentTimeMillis()), 2)
       )
     )
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     assertThrows[UnsupportedOperationException] {
       df.write
@@ -346,7 +346,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       List(StructField("Foo", IntegerType), StructField("foo", IntegerType))
     )
     val data: RDD[Row] = sc.makeRDD(List(Row(1, 2), Row(2, 3)))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     assertThrows[UnsupportedOperationException] {
       df.write
@@ -373,7 +373,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       )
     )
     val data: RDD[Row] = sc.makeRDD(List(Row(1, 2, 4), Row(2, 3, 5)))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     // no error
     df.write
@@ -407,7 +407,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       List(StructField("str", StringType), StructField("num", IntegerType))
     )
     val data: RDD[Row] = sc.makeRDD(List(Row("a", 4), Row("b", 5)))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     // no error
     df.write
@@ -442,7 +442,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       List(StructField("foo", StringType), StructField("bar", IntegerType))
     )
     val data: RDD[Row] = sc.makeRDD(List(Row("a", 4), Row("b", 5)))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     assertThrows[UnsupportedOperationException] {
       df.write
@@ -464,7 +464,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       StructField("a1", IntegerType)
     ))
     val data: RDD[Row] = sc.makeRDD(List(Row("val", 4, 5)))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     // Create table and write data with column_mapping = "order"
     df.write.format("snowflake")
@@ -524,7 +524,7 @@ class ColumnMappingIntegrationSuite extends IntegrationSuiteBase {
       StructField("c1", StringType)
     ))
     val data: RDD[Row] = sc.makeRDD(List(Row("A", "B", "C")))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     // Create table and write data with column_mapping = "order"
     df.write.format("snowflake")

--- a/src/it/scala/net/snowflake/spark/snowflake/ColumnNameCaseSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/ColumnNameCaseSuite.scala
@@ -36,7 +36,7 @@ class ColumnNameCaseSuite extends IntegrationSuiteBase {
     )
     val data = sc.makeRDD(List(Row(1, null), Row(null, "b")))
 
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     df.write
       .format(SNOWFLAKE_SOURCE_SHORT_NAME)
@@ -63,7 +63,7 @@ class ColumnNameCaseSuite extends IntegrationSuiteBase {
     )
     val data = sc.makeRDD(List(Row(1, null), Row(null, "b")))
 
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     df.write
       .format(SNOWFLAKE_SOURCE_SHORT_NAME)
@@ -95,7 +95,7 @@ class ColumnNameCaseSuite extends IntegrationSuiteBase {
 
     val data: RDD[Row] = sc.makeRDD(List(Row(1, 2)))
 
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = sparkSession.createDataFrame(data, schema)
 
     df.write
       .format(SNOWFLAKE_SOURCE_NAME)

--- a/src/it/scala/net/snowflake/spark/snowflake/DataTypesIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/DataTypesIntegrationSuite.scala
@@ -41,7 +41,7 @@ class DataTypesIntegrationSuite extends IntegrationSuiteBase {
   }
 
   def checkTestTable(expectedAnswer: Seq[Row]): Unit = {
-    val loadedDf = sqlContext.read
+    val loadedDf = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("query", s"select * from $test_table order by i")

--- a/src/it/scala/net/snowflake/spark/snowflake/DecimalIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/DecimalIntegrationSuite.scala
@@ -56,7 +56,7 @@ class DecimalIntegrationSuite extends IntegrationSuiteBase {
         }
         conn.commit()
         assert(DefaultJDBCWrapper.tableExists(conn, tableName))
-        val loadedDf = sqlContext.read
+        val loadedDf = sparkSession.read
           .format(SNOWFLAKE_SOURCE_NAME)
           .options(connectorOptions)
           .option("dbtable", tableName)

--- a/src/it/scala/net/snowflake/spark/snowflake/FilterPushdownIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/FilterPushdownIntegrationSuite.scala
@@ -104,7 +104,7 @@ class FilterPushdownIntegrationSuite extends IntegrationSuiteBase {
   def testFilter(filter: String,
                  expectedWhere: String,
                  expectedAnswer: Seq[Row]): Unit = {
-    val loadedDf = sqlContext.read
+    val loadedDf = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("dbtable", s"$test_table")

--- a/src/it/scala/net/snowflake/spark/snowflake/FullNewPushdownIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/FullNewPushdownIntegrationSuite.scala
@@ -57,7 +57,7 @@ class FullNewPushdownIntegrationSuite extends IntegrationSuiteBase {
       )
     )
 
-    val df1_spark = sqlContext
+    val df1_spark = sparkSession
       .createDataFrame(
         sc.parallelize(1 to numRows1)
           .map[Row](value => {
@@ -75,7 +75,7 @@ class FullNewPushdownIntegrationSuite extends IntegrationSuiteBase {
       .cache()
 
     // Contains some nulls
-    val df2_spark = sqlContext
+    val df2_spark = sparkSession
       .createDataFrame(
         sc.parallelize(1 to numRows2)
           .map[Row](value => {
@@ -324,7 +324,7 @@ class FullNewPushdownIntegrationSuite extends IntegrationSuiteBase {
       jdbcUpdate(s"drop table if exists $test_join_right")
     } finally {
       super.afterAll()
-      SnowflakeConnectorUtils.disablePushdownSession(sqlContext.sparkSession)
+      SnowflakeConnectorUtils.disablePushdownSession(sparkSession)
     }
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/IssueSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IssueSuite.scala
@@ -48,7 +48,7 @@ class IssueSuite extends IntegrationSuiteBase {
         .mode(SaveMode.Overwrite)
         .save()
 
-      val loadDf = sqlContext.read
+      val loadDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptions)
         .option("dbtable", tt)
@@ -81,7 +81,7 @@ class IssueSuite extends IntegrationSuiteBase {
     val tt: String = s"tt_$randomSuffix"
 
     try {
-      sqlContext
+      sparkSession
         .createDataFrame(
           sc.parallelize(1 to numRows)
             .map[Row](value => {
@@ -103,7 +103,7 @@ class IssueSuite extends IntegrationSuiteBase {
         .mode(SaveMode.Overwrite)
         .save()
 
-      val loadedDf = sqlContext.read
+      val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptionsNoTable)
         .option("dbtable", tt)
@@ -136,7 +136,7 @@ class IssueSuite extends IntegrationSuiteBase {
         else rand.nextString(10)
       }
 
-      sqlContext
+      sparkSession
         .createDataFrame(
           sc.parallelize(1 to numRows)
             .map[Row](value => {
@@ -152,7 +152,7 @@ class IssueSuite extends IntegrationSuiteBase {
         .mode(SaveMode.Overwrite)
         .save()
 
-      val loadedDf = sqlContext.read
+      val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptionsNoTable)
         .option("dbtable", tt)
@@ -183,7 +183,7 @@ class IssueSuite extends IntegrationSuiteBase {
         else rand.nextString(10)
       }
 
-      sqlContext
+      sparkSession
         .createDataFrame(
           sc.parallelize(1 to numRows)
             .map[Row](value => {
@@ -204,7 +204,7 @@ class IssueSuite extends IntegrationSuiteBase {
 
       assert(Utils.getLastCopyLoad contains "TRUNCATECOLUMNS = TRUE")
 
-      val loadedDf = sqlContext.read
+      val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptionsNoTable)
         .option("dbtable", tt)
@@ -236,7 +236,7 @@ class IssueSuite extends IntegrationSuiteBase {
         else rand.nextString(10)
       }
 
-      sqlContext
+      sparkSession
         .createDataFrame(
           sc.parallelize(1 to numRows)
             .map[Row](value => {
@@ -252,7 +252,7 @@ class IssueSuite extends IntegrationSuiteBase {
         .mode(SaveMode.Overwrite)
         .save()
 
-      val loadedDf = sqlContext.read
+      val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptionsNoTable)
         .option("dbtable", tt)

--- a/src/it/scala/net/snowflake/spark/snowflake/OnErrorSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/OnErrorSuite.scala
@@ -12,7 +12,7 @@ class OnErrorSuite extends IntegrationSuiteBase {
     Array(StructField("var", StringType, nullable = false))
   )
 
-  lazy val df: DataFrame = sqlContext.createDataFrame(
+  lazy val df: DataFrame = sparkSession.createDataFrame(
     sc.parallelize(
       Seq(Row("{\"dsadas\nadsa\":12311}"), Row("{\"abc\":334}")) // invalid json key
     ),
@@ -50,7 +50,7 @@ class OnErrorSuite extends IntegrationSuiteBase {
       .mode(SaveMode.Append)
       .save()
 
-    val result = sqlContext.read
+    val result = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("dbtable", table)

--- a/src/it/scala/net/snowflake/spark/snowflake/SecuritySuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SecuritySuite.scala
@@ -109,7 +109,7 @@ class SecuritySuite extends IntegrationSuiteBase {
       jdbcUpdate(s"drop table if exists $test_table_write")
     } finally {
       super.afterAll()
-      SnowflakeConnectorUtils.disablePushdownSession(sqlContext.sparkSession)
+      SnowflakeConnectorUtils.disablePushdownSession(sparkSession)
     }
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/SimpleNewPushdownIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SimpleNewPushdownIntegrationSuite.scala
@@ -458,7 +458,7 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
       jdbcUpdate(s"drop table if exists $test_table3")
     } finally {
       super.afterAll()
-      SnowflakeConnectorUtils.disablePushdownSession(sqlContext.sparkSession)
+      SnowflakeConnectorUtils.disablePushdownSession(sparkSession)
     }
   }
 }

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -871,7 +871,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
     } finally {
       TestHook.disableTestHook()
       super.afterAll()
-      SnowflakeConnectorUtils.disablePushdownSession(sqlContext.sparkSession)
+      SnowflakeConnectorUtils.disablePushdownSession(sparkSession)
     }
   }
 }

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetryIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetryIntegrationSuite.scala
@@ -44,7 +44,7 @@ class SnowflakeTelemetryIntegrationSuite extends IntegrationSuiteBase {
       )
     )
 
-    val df1_spark = sqlContext
+    val df1_spark = sparkSession
       .createDataFrame(
         sc.parallelize(1 to numRows1)
           .map[Row](value => {
@@ -62,7 +62,7 @@ class SnowflakeTelemetryIntegrationSuite extends IntegrationSuiteBase {
       .cache()
 
     // Contains some nulls
-    val df2_spark = sqlContext
+    val df2_spark = sparkSession
       .createDataFrame(
         sc.parallelize(1 to numRows2)
           .map[Row](value => {
@@ -281,7 +281,7 @@ class SnowflakeTelemetryIntegrationSuite extends IntegrationSuiteBase {
       jdbcUpdate(s"drop table if exists $test_table2")
     } finally {
       super.afterAll()
-      SnowflakeConnectorUtils.disablePushdownSession(sqlContext.sparkSession)
+      SnowflakeConnectorUtils.disablePushdownSession(sparkSession)
     }
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -25,7 +25,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
     )
   )
 
-  lazy val df1: DataFrame = sqlContext.createDataFrame(
+  lazy val df1: DataFrame = sparkSession.createDataFrame(
     sc.parallelize(1 to 100)
       .map[Row](_ => {
         val rand = new Random(System.nanoTime())
@@ -41,7 +41,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
     )
   )
 
-  lazy val df2: DataFrame = sqlContext.createDataFrame(
+  lazy val df2: DataFrame = sparkSession.createDataFrame(
     sc.parallelize(1 to 100)
       .map[Row](_ => {
         val rand = new Random(System.nanoTime())
@@ -279,7 +279,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
       .mode(SaveMode.Overwrite)
       .save()
 
-    val oldRowCount = sqlContext.read
+    val oldRowCount = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("dbtable", s"$table")
@@ -317,7 +317,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
           .save()
       }
 
-      val newRowCount = sqlContext.read
+      val newRowCount = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptionsNoTable)
         .option("dbtable", s"$table")

--- a/src/it/scala/net/snowflake/spark/snowflake/VariantTypeSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/VariantTypeSuite.scala
@@ -47,7 +47,7 @@ class VariantTypeSuite extends IntegrationSuiteBase {
   }
 
   test("unload non variant data") {
-    val df = sqlContext.read
+    val df = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("dbtable", tableName1)
@@ -61,7 +61,7 @@ class VariantTypeSuite extends IntegrationSuiteBase {
     assert(df.length == 2)
   }
   test("unload variant data") {
-    val df = sqlContext.read
+    val df = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("dbtable", tableName1)

--- a/src/it/scala/net/snowflake/spark/snowflake/streaming/StreamingSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/streaming/StreamingSuite.scala
@@ -80,7 +80,7 @@ class StreamingSuite extends IntegrationSuiteBase {
   }
 
   def checkTestTable(expectedAnswer: Seq[Row]): Unit = {
-    val loadedDf = sqlContext.read
+    val loadedDf = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("query", s"select * from $table order by value")
@@ -95,7 +95,7 @@ class StreamingSuite extends IntegrationSuiteBase {
 
   // manual test only
   ignore("test") {
-    val spark = sqlContext.sparkSession
+    val spark = sparkSession
     import spark.implicits._
 
     DefaultJDBCWrapper.executeQueryInterruptibly(
@@ -132,7 +132,7 @@ class StreamingSuite extends IntegrationSuiteBase {
 
   ignore("Test streaming writer") {
 
-    val spark = sqlContext.sparkSession
+    val spark = sparkSession
     import spark.implicits._
     val streamingStage = "streaming_test_stage"
 
@@ -211,7 +211,7 @@ class StreamingSuite extends IntegrationSuiteBase {
 
   ignore("kafka") {
 
-    val spark = sqlContext.sparkSession
+    val spark = sparkSession
     val streamingStage = "streaming_test_stage"
 
     conn.createStage(name = streamingStage, overwrite = true)
@@ -247,7 +247,7 @@ class StreamingSuite extends IntegrationSuiteBase {
 
   ignore("kafka1") {
 
-    val spark = sqlContext.sparkSession
+    val spark = sparkSession
     val streamingStage = "streaming_test_stage"
     val streamingTable = "streaming_test_table"
 


### PR DESCRIPTION
SNOW-146498

SQLContext is introduced from Spark 1.0
As of Spark 2.0, this is replaced by SparkSession.
This is for Spark 3.0 support.
