### PR TITLE
Support new result format for COPY INTO LOCATION

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeIntegrationSuite.scala
@@ -299,10 +299,10 @@ class SnowflakeIntegrationSuite extends IntegrationSuiteBase {
   test("Ability to query a UDF") {
     val funcName = s"testudf$randomSuffix"
     try {
-      Utils.runQuery(connectorOptionsNoTable, s"""
-          |CREATE OR REPLACE FUNCTION $funcName(a number, b number)
-          |RETURNS number
-          |AS 'a * b'
+      jdbcUpdate(
+        s"""CREATE OR REPLACE FUNCTION $funcName(a number, b number)
+           | RETURNS number
+           | AS 'a * b'
         """.stripMargin)
 
       val loadedDf = sparkSession.read
@@ -316,10 +316,7 @@ class SnowflakeIntegrationSuite extends IntegrationSuiteBase {
       checkAnswer(loadedDf.selectExpr("twelve"), Seq(Row(12)))
     } finally {
       // Clean up the UDF
-      Utils.runQuery(
-        connectorOptionsNoTable,
-        s"DROP FUNCTION IF EXISTS $funcName(number, number)"
-      )
+      jdbcUpdate(s"DROP FUNCTION IF EXISTS $funcName(number, number)")
     }
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -784,6 +784,27 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
     }
   }
 
+  // Test sfURL to support the sfURL to begin with http:// or https://
+  test("Test sfURL begin with http:// or https://") {
+    setupLargeResultTable
+    val origSfURL = thisConnectorOptionsNoTable("sfURL")
+    val testURLs = List(s"http://$origSfURL", s"https://$origSfURL")
+    testURLs.foreach(url => {
+      thisConnectorOptionsNoTable -= "sfURL"
+      thisConnectorOptionsNoTable += ("sfURL" -> url)
+
+      sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", s"$test_table_large_result")
+        .load()
+        .count()
+    })
+    // reset sfRUL
+    thisConnectorOptionsNoTable -= "sfURL"
+    thisConnectorOptionsNoTable += ("sfURL" -> origSfURL)
+  }
+
   // Negative test for hitting exception when uploading data to cloud
   test("Test GCP uploading retry works") {
     setupLargeResultTable

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -445,7 +445,13 @@ object Parameters {
       * URL pointing to the snowflake database, simply
       *   host:port
       */
-    def sfURL: String = parameters(PARAM_SF_URL)
+    def sfURL: String = {
+      var url = parameters(PARAM_SF_URL)
+      if (url.matches("https?://.*")) {
+        url = url.substring(url.indexOf("//") + 2)
+      }
+      url
+    }
 
     /**
       * Snowflake database name
@@ -549,10 +555,9 @@ object Parameters {
       */
     def setColumnMap(fromSchema: Option[StructType],
                      toSchema: Option[StructType]): Unit = {
-      assert(
-        parameters.get(PARAM_COLUMN_MAP).isEmpty,
-        "Column map is already declared"
-      )
+      if (parameters.get(PARAM_COLUMN_MAP).isDefined) {
+        throw new Exception("Column map is already declared")
+      }
       generatedColumnMap =
         if (columnMapping == "name" && fromSchema.isDefined && toSchema.isDefined) {
           val map = Utils.generateColumnMap(

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
@@ -54,9 +54,6 @@ private[snowflake] class SnowflakeWriter(jdbcWrapper: JDBCWrapper) {
            data: DataFrame,
            saveMode: SaveMode,
            params: MergedParameters): Unit = {
-
-
-
     val format: SupportedFormat =
       if (Utils.containVariant(data.schema)) SupportedFormat.JSON
       else SupportedFormat.CSV

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -223,9 +223,11 @@ object Utils {
   private def mapFromSource(src: Source): Map[String, String] = {
     var map = new mutable.HashMap[String, String]
     for (line <- src.getLines()) {
-
       val index = line.indexOf('=')
-      assert(index > 0, "Can't parse this line: " + line)
+      if (index < 1) {
+        throw new Exception(
+          s"Can't parse the line of $line. The index of '=' is $index")
+      }
       val key = line.substring(0, index).trim.toLowerCase
       val value = line.substring(index + 1).trim
       if (!key.startsWith("#")) {


### PR DESCRIPTION
1. The result is checked to send the telemetry message.
   If the result format is not recognized, log a warning message
2. Send the similar telemetry message for Arrow Format
3. Replace all usages of assert() in production with readable Exception