### PR TITLE
SNOW-173710 Leverage Spark retry-mechanism to handle throttling issue.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,14 @@ import scala.util.Properties
 
 val sparkVersion = "3.0.0"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
+
+/*
+ * Don't change the variable name "sparkConnectorVersion" because
+ * jenkins job "BumpUpSparkConnectorVersion" depends on it.
+ * If it has to be changed, please also change the script:
+ * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
+ * in snowflake repository.
+ */
 val sparkConnectorVersion = "2.8.0"
 
 lazy val ItTest = config("it") extend Test

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -126,6 +126,11 @@ object Parameters {
     "expected_partition_count"
   )
   val PARAM_MAX_RETRY_COUNT: String = knownParam("max_retry_count")
+  // When a spark task fails because of a throttling issue,
+  // the task should use exponential backoff for next retry.
+  val PARAM_USE_EXPONENTIAL_BACKOFF: String = knownParam(
+    "use_exponential_backoff"
+  )
 
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
@@ -169,7 +174,8 @@ object Parameters {
     PARAM_USE_COPY_UNLOAD -> "false",
     PARAM_USE_PROXY -> "false",
     PARAM_EXPECTED_PARTITION_COUNT -> "1000",
-    PARAM_MAX_RETRY_COUNT -> "10"
+    PARAM_MAX_RETRY_COUNT -> "10",
+    PARAM_USE_EXPONENTIAL_BACKOFF -> "off"
   )
 
   /**
@@ -551,6 +557,9 @@ object Parameters {
 
     def maxRetryCount: Int = {
       parameters.getOrElse(PARAM_MAX_RETRY_COUNT, "10").toInt
+    }
+    def useExponentialBackoff: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_USE_EXPONENTIAL_BACKOFF, "false"))
     }
 
     /**


### PR DESCRIPTION
When the spark task fails, this task will be rescheduled by spark until the max attempt number is arrived. So we can leverage the spark retry instead of implementing retry in spark connector. Spark sleeps 3 seconds by default before reschedule. To handle cloud storage service throttling issue, it is necessary to use exponential sleep time (spark doesn’t support it). So, we introduce extra exponential sleep time based on the task’s attempt number.