### PR TITLE
SNOW-170311 Send specific unsupported operation in generateQueries.

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -116,6 +116,11 @@ class SnowflakePushdownException(message: String)
 class SnowflakeConnectorFeatureNotSupportException(message: String)
   extends Exception(message)
 
+object SnowflakeFailMessage {
+  final val FAIL_PUSHDOWN_STATEMENT = "pushdown failed"
+  final val FAIL_PUSHDOWN_GENERATE_QUERY = "pushdown failed in generateQueries"
+}
+
 class SnowflakePushdownUnsupportedException(message: String,
                                             val unsupportedOperation: String,
                                             val details: String,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/UnsupportedStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/UnsupportedStatement.scala
@@ -14,9 +14,6 @@ import org.apache.spark.sql.execution.aggregate.ScalaUDAF
   * to stop the push-down to snowflake.
   */
 private[querygeneration] object UnsupportedStatement {
-
-  final val EXCEPTION_MESSAGE = "pushdown failed"
-
   /** Used mainly by QueryGeneration.convertStatement. This matches
     * a tuple of (Expression, Seq[Attribute]) representing the expression to
     * be matched and the fields that define the valid fields in the current expression
@@ -37,7 +34,7 @@ private[querygeneration] object UnsupportedStatement {
     // there are any snowflake tables in the query. It can't be done here
     // because it is not clear whether there are any snowflake tables here.
     throw new SnowflakePushdownUnsupportedException(
-      EXCEPTION_MESSAGE,
+      SnowflakeFailMessage.FAIL_PUSHDOWN_STATEMENT,
       expr.prettyName,
       expr.sql,
       isKnownUnsupportedOperation(expr))


### PR DESCRIPTION
Before the enhancement, if generateQueries() meets unsupported
operation, it returns None, so a pushdown failure message for
"NoSuchElementException" is sent. It is unclear. With this fix,
specific info about the unsupported operation is sent.