### PR TITLE
SNOW-175796 Send unsupported function name for aggregate function

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -117,9 +117,11 @@ class SnowflakeConnectorFeatureNotSupportException(message: String)
   extends Exception(message)
 
 object SnowflakeFailMessage {
+  // Note: don't change the message context except necessary
   final val FAIL_PUSHDOWN_STATEMENT = "pushdown failed"
   final val FAIL_PUSHDOWN_GENERATE_QUERY = "pushdown failed in generateQueries"
   final val FAIL_PUSHDOWN_SET_TO_EXPR = "pushdown failed in setToExpr"
+  final val FAIL_PUSHDOWN_AGGREGATE_EXPRESSION = "pushdown failed for aggregate expression"
 }
 
 class SnowflakePushdownUnsupportedException(message: String,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/AggregationStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/AggregationStatement.scala
@@ -3,6 +3,8 @@ package net.snowflake.spark.snowflake.pushdowns.querygeneration
 import net.snowflake.spark.snowflake.{
   ConstantString,
   EmptySnowflakeSQLStatement,
+  SnowflakeFailMessage,
+  SnowflakePushdownUnsupportedException,
   SnowflakeSQLStatement
 }
 import org.apache.spark.sql.catalyst.expressions._
@@ -18,22 +20,35 @@ private[querygeneration] object AggregationStatement {
     val expr = expAttr._1
     val fields = expAttr._2
 
-    // Take only the first child, as all of the functions below have only one.
-    expr.children.headOption.flatMap(agg_fun => {
-      Option(agg_fun match {
-        case _: Average | _: Corr | _: CovPopulation | _: CovSample | _: Count |
-            _: Max | _: Min | _: Sum | _: StddevPop | _: StddevSamp |
-            _: VariancePop | _: VarianceSamp =>
-          val distinct: SnowflakeSQLStatement =
-            if (expr.sql contains "(DISTINCT ") ConstantString("DISTINCT") !
-            else EmptySnowflakeSQLStatement()
+    expr match {
+      case _: AggregateExpression =>
+        // Take only the first child, as all of the functions below have only one.
+        expr.children.headOption.flatMap(agg_fun => {
+          Option(agg_fun match {
+            case _: Average | _: Corr | _: CovPopulation | _: CovSample | _: Count |
+                 _: Max | _: Min | _: Sum | _: StddevPop | _: StddevSamp |
+                 _: VariancePop | _: VarianceSamp =>
+              val distinct: SnowflakeSQLStatement =
+                if (expr.sql contains "(DISTINCT ") ConstantString("DISTINCT") !
+                else EmptySnowflakeSQLStatement()
 
-          ConstantString(agg_fun.prettyName.toUpperCase) +
-            blockStatement(
-              distinct + convertStatements(fields, agg_fun.children: _*)
-            )
-        case _ => null
-      })
-    })
+              ConstantString(agg_fun.prettyName.toUpperCase) +
+                blockStatement(
+                  distinct + convertStatements(fields, agg_fun.children: _*)
+                )
+            case _ =>
+              // This exception is not a real issue. It will be caught in
+              // QueryBuilder.treeRoot and a telemetry message will be sent if
+              // there are any snowflake tables in the query.
+              throw new SnowflakePushdownUnsupportedException(
+                SnowflakeFailMessage.FAIL_PUSHDOWN_AGGREGATE_EXPRESSION,
+                s"${agg_fun.prettyName} @ AggregationStatement",
+                agg_fun.sql,
+                false
+              )
+          })
+        })
+      case _ => None
+    }
   }
 }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
@@ -101,7 +101,7 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) {
             plan,
             new SnowflakePushdownUnsupportedException(
               e.getMessage,
-              e.getClass.toString,
+              s"${e.getClass.toString} @ QueryBuilder.treeRoot",
               stringWriter.toString,
               false
             )


### PR DESCRIPTION
Currently, telemetry message with "aggregateexpression' is sent
for unsupported aggregate function. It's unclear.