### PR TITLE
SNOW-177689 Enable IT for GCP

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -19,7 +19,7 @@ jobs:
        # chunks from GCP. It is not a Spark Connector issue because the test	
        # runs well on Travis and local. SNOW-177689 is filed to investigate it	
        # Before that, the test on GCP is disabled to avoid blocking others.	
-       cloud_provider: [ 'aws', 'azure' ]
+       cloud_provider: [ 'aws', 'azure', 'gcp' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -15,10 +15,6 @@ jobs:
        scala_version: [ '2.12.11' ]
        spark_version: [ '3.0.0' ]
        use_copy_unload: [ 'true', 'false' ]
-       # The test on gcp hangs because of the timeout when downloading data
-       # chunks from GCP. It is not a Spark Connector issue because the test	
-       # runs well on Travis and local. SNOW-177689 is filed to investigate it	
-       # Before that, the test on GCP is disabled to avoid blocking others.	
        cloud_provider: [ 'aws', 'azure', 'gcp' ]
 
     steps:


### PR DESCRIPTION
The IT test on GCP is disabled because environment issue. Now, it looks the env issue has been resolved. re-enable it.