### PR TITLE
SNOW-180368 Add format check for unix_timestamp() pushdown

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement03.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement03.scala
@@ -56,13 +56,19 @@ class PushdownEnhancement03 extends IntegrationSuiteBase {
   }
 
   test("test pushdown function: unix_timestamp() for String") {
-    jdbcUpdate(s"create or replace table $test_table_unix_timestamp " +
-      s"(s1_standard string, s2_ddMMyy string, s3_dd_MM_yyyy string," +
-      s"s4_yyyyMMdd string, s5_yyMMdd string, s6_MMdd string, s7_ddMMyyyy string)")
+    jdbcUpdate(
+      s"""create or replace table $test_table_unix_timestamp (
+      | s1_standard string, s2_ddMMyy string, s3_dd_MM_yyyy string,
+      | s4_yyyyMMdd string, s5_yyMMdd string, s6_MMdd string,
+      | s7_ddMMyyyy string, s8_SSS string, s9_literal1 string,
+      | s10_literal2 string)
+      |""".stripMargin)
     // Note: Spark default format is "yyyy-MM-dd HH:mm:ss"
     jdbcUpdate(s"""insert into $test_table_unix_timestamp values
                | ('2017-01-01 12:12:12', '31072020', '31/07/2020',
-               | '20200731', '200731', '0731', '31072020')
+               | '20200731', '200731', '0731', '31072020',
+               | '2017/01/30 12:12:12.123', '2017.01.01T12:12:12Z',
+               | 'year: 2012, month: 01, day: 30')
                | """.stripMargin)
 
     val tmpDF = sparkSession.read
@@ -79,6 +85,9 @@ class PushdownEnhancement03 extends IntegrationSuiteBase {
       unix_timestamp(col("s5_yyMMdd"), "yyMMdd"),
       unix_timestamp(col("s6_MMdd"), "MMdd"),
       unix_timestamp(col("s7_ddMMyyyy"), "ddMMyyyy"),
+      unix_timestamp(col("s8_SSS"), "yyyy/MM/dd HH:mm:ss.SSS"),
+      unix_timestamp(col("s9_literal1"), "yyyy.MM.dd'T'HH:mm:ss'Z'"),
+      unix_timestamp(col("s10_literal2"), "'year: 'yyyy', month: 'MM', day: 'dd")
     )
 
     // resultDF.printSchema()
@@ -86,8 +95,9 @@ class PushdownEnhancement03 extends IntegrationSuiteBase {
 
     // The expected result is generated when pushdown is disabled.
     val expectedResult = Seq(
-      Row(1483272732.toLong, 1596153600.toLong, 1596153600.toLong,
-        1596153600.toLong, 1596153600.toLong, 18230400.toLong, 1596153600.toLong
+      Row(1483272732L, 1596153600L, 1596153600L,
+        1596153600L, 1596153600L, 18230400L, 1596153600L,
+        1485778332L, 1483272732L, 1327881600L
       )
     )
 
@@ -113,7 +123,17 @@ class PushdownEnhancement03 extends IntegrationSuiteBase {
          |      'MMdd' ) ) ) AS "SUBQUERY_1_COL_5" ,
          |  ( DATE_PART('epoch_second',
          |    TO_TIMESTAMP ( "SUBQUERY_0"."S7_DDMMYYYY" ,
-         |      'ddMMyyyy' ) ) ) AS "SUBQUERY_1_COL_6"
+         |      'ddMMyyyy' ) ) ) AS "SUBQUERY_1_COL_6" ,
+         |  ( DATE_PART('EPOCH_SECOND',
+         |    TO_TIMESTAMP ( "SUBQUERY_0"."S8_SSS" ,
+         |      'yyyy/MM/dd HH:MI:ss.FF3' ) ) ) AS "SUBQUERY_1_COL_7",
+         |  ( DATE_PART('EPOCH_SECOND',
+         |    TO_TIMESTAMP ( "SUBQUERY_0"."S9_LITERAL1" ,
+         |      'yyyy.MM.dd"T"HH:MI:ss"Z"' ) ) ) AS "SUBQUERY_1_COL_8",
+         |  ( DATE_PART('EPOCH_SECOND',
+         |    TO_TIMESTAMP ( "SUBQUERY_0"."S10_LITERAL2" ,
+         |      '"year: "yyyy", month: "MM", day: "dd' ) ) )
+         |        AS "SUBQUERY_1_COL_9"
          |FROM ( SELECT * FROM ( $test_table_unix_timestamp )
          |   AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
          |""".stripMargin,
@@ -255,6 +275,66 @@ class PushdownEnhancement03 extends IntegrationSuiteBase {
          |  ( "SUBQUERY_0"."TZ" ) AS "SUBQUERY_1_COL_9" ,
          |  ( "SUBQUERY_0"."TZ" ) AS "SUBQUERY_1_COL_10"
          |FROM ( SELECT * FROM ( $test_table_time_add )
+         |   AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+         |""".stripMargin,
+      resultDF,
+      expectedResult
+    )
+  }
+
+  test("test TimeSub/TimeAdd combines with unix_timestamp") {
+    jdbcUpdate(s"create or replace table $test_table_unix_timestamp (s1 string, s2 string)")
+    // dataformat 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+    jdbcUpdate(s"insert into $test_table_unix_timestamp values ('2017-12-31T12:12:12Z', '2017.12.31T12:12:12Z')")
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_unix_timestamp)
+      .load()
+
+    tmpDF.createOrReplaceTempView("test_table_unix_timestamp")
+
+    val resultDF = sparkSession.sql(
+      s"""select
+         |  s1,
+         |  CAST(unix_timestamp(s1, "yyyy-MM-dd'T'HH:mm:ss'Z'") AS TIMESTAMP) - interval 4 hours,
+         |  CAST(unix_timestamp(s2, "yyyy.MM.dd'T'HH:mm:ss'Z'") AS TIMESTAMP) + interval 4 minutes,
+         |  CAST(unix_timestamp(s2, "yyyy.MM.dd'T'HH:mm:ssZ") AS TIMESTAMP) + interval 4 seconds
+         | from test_table_unix_timestamp
+         | """.stripMargin
+    )
+
+    // resultDF.printSchema()
+    // resultDF.show(truncate = false)
+
+    // The expected result is generated when pushdown is disabled.
+    val expectedResult = Seq(Row(
+      "2017-12-31T12:12:12Z",
+      Timestamp.valueOf("2017-12-31 08:12:12"), // - 4 hours
+      Timestamp.valueOf("2017-12-31 12:16:12"), // + 4 minutes
+      Timestamp.valueOf("2017-12-31 12:12:16")  // + 4 seconds
+    ))
+
+    testPushdown(
+      s"""SELECT
+         |  ( "SUBQUERY_0"."S1" ) AS "SUBQUERY_1_COL_0" ,
+         |  ( DATEADD ( 'MICROSECOND', (0 - (14400000000)),
+         |    CAST ( DATE_PART('EPOCH_SECOND',
+         |                     TO_TIMESTAMP ("SUBQUERY_0"."S1" ,
+         |                                   'yyyy-MM-dd"T"HH:MI:ss"Z"' )
+         |           ) AS TIMESTAMP ) ) ) AS "SUBQUERY_1_COL_1" ,
+         |  ( DATEADD ( 'MICROSECOND', 240000000,
+         |    CAST ( DATE_PART('EPOCH_SECOND',
+         |                     TO_TIMESTAMP ("SUBQUERY_0"."S2" ,
+         |                                   'yyyy.MM.dd"T"HH:MI:ss"Z"' )
+         |           ) AS TIMESTAMP ) ) ) AS "SUBQUERY_1_COL_2",
+         |  ( DATEADD ( 'MICROSECOND', 4000000,
+         |    CAST ( DATE_PART('EPOCH_SECOND',
+         |                     TO_TIMESTAMP ("SUBQUERY_0"."S2" ,
+         |                                   'yyyy.MM.dd"T"HH:MI:ssZ' )
+         |            ) AS TIMESTAMP ) ) ) AS "SUBQUERY_1_COL_3"
+         |FROM ( SELECT * FROM ( $test_table_unix_timestamp )
          |   AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
          |""".stripMargin,
       resultDF,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -72,16 +72,25 @@ private[querygeneration] object DateStatement {
               blockStatement(convertStatement(timeExp, fields)) + ")"
 
           case StringType =>
-            // Spark uses Java SimpleDateFormat pattern for 'format'.
-            // https://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html
-            // The format is some different to Snowflake's timestamp format.
-            // One different is that Spark uses 'mm' stand for minutes,
-            // but Snowflake uses 'MI', so it needs to be converted before
-            // passing to snowflake.
-            val sfFormat = format.toString().replaceAll("mm", "MI")
-            ConstantString("DATE_PART('EPOCH_SECOND', TO_TIMESTAMP") +
-              blockStatement(convertStatement(timeExp, fields) +
-                s",'$sfFormat'") + ")"
+            // Spark uses Java SimpleDateFormat pattern for 'format'
+            // which is different to Snowflake's timestamp format.
+            // So, it needs to be converted before being passed to snowflake.
+            // If the format are not supported by Snowflake, it is not
+            // pushdown to snowflake.
+            // Note: the format validity check is basic, It is possible that
+            //       some unsupported format is passed. But it doesn't matter
+            //       because snowflake will raise error for unsupported format.
+            //       Spark will retry without the pushdown to make sure the
+            //       final result to be correct.
+            getSnowflakeTimestampFormat(format.toString()) match {
+              case Some(sfFormat) =>
+                ConstantString("DATE_PART('EPOCH_SECOND', TO_TIMESTAMP") +
+                  blockStatement(convertStatement(timeExp, fields) +
+                    s",'$sfFormat'") + ")"
+              case _ =>
+                // If the format is not supported, it is not pushdown.
+                null
+            }
         }
 
       // Snowflake has no direct TimeSub function,
@@ -155,4 +164,72 @@ private[querygeneration] object DateStatement {
     resultStmt
   }
 
+  // Spark uses Java SimpleDateFormat pattern for 'format'.
+  // So it needs to be converted before being passed to snowflake.
+  // The format can be converted to Snowflake format if it only includes
+  // below parts:
+  // 1. Year:               valid value is: "yy" or "yyyy"
+  // 2. month in year:      valid value is: "MM"
+  // 3. day in month:       valid value is: "dd"
+  // 4. hour in day:        valid value is: "HH"
+  // 5. minute in hour:     valid value is: "mm"
+  // 6. second in minute:   valid value is: "ss"
+  // 7. millisecond:        valid value is: "SSS"
+  // 8. Literal:  quoted sting or non-special letters
+  // Note: This is a basic check. It is possible that some
+  //       unsupported format are passed. But it doesn't matter
+  //       snowflake will raise error for unsupported format.
+  //       Spark will retry without the pushdown to make sure the
+  //       final result to be correct.
+  private[querygeneration] def getSnowflakeTimestampFormat(format: String)
+  : Option[String] = {
+    // Below page includes the list of symbols used for Java Timestamp format.
+    // The format is regarded as supported if there is no unsupported chars.
+    // https://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html
+    val unsupportedChars = Set(
+      'G', // era designator
+      'h', // hour in am/pm (1-12)
+      'E', // day in week
+      'D', // day in year
+      'F', // day of week in month
+      'w', // week in year
+      'W', // week in month
+      'a', // am/pm marker
+      'k', // hour in day (1-24)
+      'K', // hour in am/pm (0-11)
+      'z'  // time zone
+    )
+
+    var inLiteral = false
+    var foundUnsupportedChar = false
+    // Determine whether there is unsupported format.
+    format.foreach(c => {
+      if (c == '\'') {
+        inLiteral = !inLiteral
+      } else if (!inLiteral) {
+        if (unsupportedChars.contains(c)) {
+          foundUnsupportedChar = true
+        }
+      } else {
+        // Skip the check for quoted literal.
+      }
+    })
+
+    if (foundUnsupportedChar || inLiteral) {
+      log.info(s"DateStatement: unsupported format '$format'")
+      None
+    } else {
+      // The format is supported, convert it to snowflake format by
+      // replacing 3 patterns:
+      // 1. Java uses 'mm' stand for minutes, but Snowflake uses 'MI',
+      // 2. Java use "SSS" for millisecond, but Snowflake uses "FF3"
+      // 3. Java uses single quote for Literal string,
+      //    but Snowflake uses double quote
+      Some(format
+        .replaceAll("mm", "MI")
+        .replaceAll("SSS", "FF3")
+        .replaceAll("'", "\"")
+      )
+    }
+  }
 }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.types.{StructField, StructType}
+import org.slf4j.LoggerFactory
 
 import scala.reflect.ClassTag
 
@@ -38,6 +39,11 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) {
     * Indicate whether any snowflake tables are involved in a query plan.
     */
   private var foundSnowflakeRelation = false
+
+  /**
+    * Logger for pushdown processing
+    */
+  private[querygeneration] val log = LoggerFactory.getLogger(getClass)
 
   /** This iterator automatically increments every time it is used,
     * and is for aliasing subqueries.

--- a/src/test/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/PushdownSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/PushdownSuite01.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Snowflake Computing
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.snowflake.spark.snowflake.pushdowns.querygeneration
+
+import java.net.URI
+
+import net.snowflake.spark.snowflake.Utils
+import org.scalatest.{FunSuite, Matchers}
+import net.snowflake.spark.snowflake.Utils
+import net.snowflake.spark.snowflake.pushdowns.querygeneration._
+
+/**
+  * Unit tests for helper functions
+  */
+class PushdownSuite01 extends FunSuite with Matchers {
+
+  test("test DateStatement.getSnowflakeTimestampFormat") {
+    assert(DateStatement.getSnowflakeTimestampFormat(
+      "yyyy-MM-dd HH:mm:ss").get.equals("yyyy-MM-dd HH:MI:ss"))
+    assert(DateStatement.getSnowflakeTimestampFormat(
+      "yyyy/MM/dd HH:mm:ss.SSS").get.equals("yyyy/MM/dd HH:MI:ss.FF3"))
+    assert(DateStatement.getSnowflakeTimestampFormat(
+      "yyyy-MM-dd'T'HH:mm:ss'Z'").get.equals("yyyy-MM-dd\"T\"HH:MI:ss\"Z\""))
+    assert(DateStatement.getSnowflakeTimestampFormat(
+      "'year: 'yyyy'month: 'MM'day'dd").get.equals("\"year: \"yyyy\"month: \"MM\"day\"dd"))
+
+    // negative test
+    assert(DateStatement.getSnowflakeTimestampFormat(
+      "G yyyy-MM-dd HH:mm:ss").isEmpty)
+    assert(DateStatement.getSnowflakeTimestampFormat(
+      "yyyy-MM-dd'T'HH:mm:ss'Z").isEmpty)
+  }
+}
+


### PR DESCRIPTION
Perform a format check for pushdown unix_timestamp() on string column.
Only enable the pushdown if the format is supported by Snowflake.