### PR TITLE
Add limit 1 for aggregates with no grouping expressions

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/ColumnNameCaseSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/ColumnNameCaseSuite.scala
@@ -138,7 +138,7 @@ class ColumnNameCaseSuite extends IntegrationSuiteBase {
       s"""
          |SELECT ( COUNT ( 1 ) ) AS "SUBQUERY_2_COL_0" FROM ( SELECT * FROM
          |( SELECT * FROM ( $table3 ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS
-         | "SUBQUERY_0" GROUP BY "SUBQUERY_0"."col" ) AS "SUBQUERY_1"
+         | "SUBQUERY_0" GROUP BY "SUBQUERY_0"."col" ) AS "SUBQUERY_1" LIMIT 1
          |""".stripMargin.replaceAll("\\s", "")
 
     assert(Utils.getLastSelect.replaceAll("\\s", "").equals(result))

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
@@ -235,7 +235,7 @@ class PushdownEnhancement01 extends IntegrationSuiteBase {
          |(to_decimal((sum((cast("subquery_0"."c2"asdecimal(5,0))
          |*pow(10,0)))/pow(10,0)),15,0))as"subquery_1_col_1"
          |FROM ( SELECT * FROM ( $test_table_decimal ) AS
-         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" """.stripMargin,
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" limit 1""".stripMargin,
       result,
       expectedResult
     )

--- a/src/it/scala/org/apache/spark/sql/SFDataFrameAggregateSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDataFrameAggregateSuite.scala
@@ -23,8 +23,6 @@ class SFDataFrameAggregateSuite
       // replaced by TS - grouping and grouping_id, replaced AnalysisException by
       // SnowflakeSQLException
       "grouping and grouping_id",
-      // possible failure due to pushdown bug. investigation tracked in SNOW-201486
-      "agg without groups and functions",
       // replaced by TS - count, SF does not support DataFrame.rdd
       "count",
       // replace by TS - stddev, floating point issue

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/SnowflakeQuery.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/SnowflakeQuery.scala
@@ -212,7 +212,9 @@ case class AggregateQuery(columns: Seq[NamedExpression],
       ConstantString("GROUP BY") +
         mkStatement(groups.map(expressionToStatement), ",")
     } else {
-      EmptySnowflakeSQLStatement()
+      // SNOW-201486: Insert a limit 1 to ensure that only one row returns if there
+      // are no grouping expressions
+      ConstantString("LIMIT 1").toStatement
     }
 }
 


### PR DESCRIPTION
This applies the 'limit 1' fix for aggregate expressions pushed down in queries where there is no grouping expression.

Removing the blacklisted item from SFDataFrameAggregateSuite effectively adds a test for this item.