### PR TITLE
Un-blacklist passing tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,10 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "org.apache.spark" %% "spark-catalyst" % testSparkVersion % "provided, test",
       "org.apache.spark" %% "spark-core" % testSparkVersion % "provided, test" classifier "tests",
       "org.apache.spark" %% "spark-sql" % testSparkVersion % "provided, test" classifier "tests",
-      "org.apache.spark" %% "spark-catalyst" % testSparkVersion % "provided, test" classifier "tests"
+      "org.apache.spark" %% "spark-catalyst" % testSparkVersion % "provided, test" classifier "tests",
+      "org.apache.spark" %% "spark-core" % testSparkVersion % "provided, test" classifier "test-sources",
+      "org.apache.spark" %% "spark-sql" % testSparkVersion % "provided, test" classifier "test-sources",
+      "org.apache.spark" %% "spark-catalyst" % testSparkVersion % "provided, test" classifier "test-sources"
       // "org.apache.spark" %% "spark-hive" % testSparkVersion % "provided, test"
     ),
 

--- a/src/it/scala/org/apache/spark/sql/SFDataFrameAggregateSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDataFrameAggregateSuite.scala
@@ -12,76 +12,20 @@ class SFDataFrameAggregateSuite
 
   override protected def blackList: Seq[String] =
     Seq(
-      // contains RDD, replaced by TS - groupBy
-      "groupBy",
-      // column name case issue, replace by TS - SPARK-17124 agg should be ordering preserving
-      "SPARK-17124 agg should be ordering preserving",
-      // we don't support RegexpExact, it is not a SF function
-      "SPARK-18952: regexes fail codegen when used as keys due to bad forward-slash escapes",
-      // contains RDD, replaced by TS - cube
-      "cube",
-      // replaced by TS - grouping and grouping_id, replaced AnalysisException by
-      // SnowflakeSQLException
-      "grouping and grouping_id",
-      // replaced by TS - count, SF does not support DataFrame.rdd
-      "count",
-      // replace by TS - stddev, floating point issue
-      "stddev",
-      // replace by TS - moments, floating point issue, kurtosis has different output
-      "moments",
       // replace by TS - zero moments, Snowflake aggregate suite returns null instead of Double.NaN
       // Snowflake skewness function is called skew
       "zero moments",
-      // replace by TS - null moments, Snowflake skewness function is called skew
-      "null moments",
-      // Snowflake does not support collect_set and collect_list
-      "collect functions",
-      "collect functions structs",
-      "collect_set functions cannot have maps",
-      "SPARK-17641: collect functions should not collect null values",
-      "collect functions should be able to cast to array type with no null values",
-      // Replaced by TS - SPARK-14664: Decimal sum/avg over window should work.
-      // Snowflake does not support "select * from values 1.0, 2.0, 3.0 T(a)"
-      // Need to replace with "select * from values (1.0), (2.0), (3.0) T(a)"
-      "SPARK-14664: Decimal sum/avg over window should work.",
-      // Snowflake does not support collect_list
-      "SPARK-17616: distinct aggregate combined with a non-partial aggregate",
-      // skipped because Snowflake does not support pivot with multiple aggregrate functions
-      "SPARK-17237 remove backticks in a pivot result schema",
-      // Replaced by TS - aggregate function in GROUP BY
-      // Snowflake does not throw AnalysisException, throws SnowflakeSQLException instead
-      "aggregate function in GROUP BY",
-      // Snowflake does not support monotonically_increasing_id() and spark_partition_id() functions
-      "SPARK-19471: AggregationIterator does not initialize the generated result "
-        + "projection before using it",
       // Replaced by TS - SPARK-21580 ints in aggregation expressions are taken as group-by ordinal.
       // Snowflake does not have table TestData2 stored in test database
       "SPARK-21580 ints in aggregation expressions are taken as group-by ordinal.",
-      // Snowflake does not support collect_list, repartition
-      "SPARK-22223: ObjectHashAggregate should not introduce unnecessary shuffle",
       // We have different SnowflakePlans, so testing the .toString does not make sense
       "SPARK-24788: RelationalGroupedDataset.toString with unresolved exprs should not fail",
       // Snowflake does not support float type, struct()
       "SPARK-26021: NaN and -0.0 in grouping expressions",
-      // Snowflake does not support range() and count(distinct(*)) to count all distinct rows
-      "SPARK-27581: DataFrame countDistinct(\"*\") shouldn't fail with AnalysisException",
-      // Snowflake does not support tempView used in following tests and max_by, min_by, count_if
       "max_by",
       "min_by",
-      "count_if",
       // Replace Spark exception by Snowflake exception, replaced by
       // TS - SPARK-21896: Window functions inside aggregate functions
       "SPARK-21896: Window functions inside aggregate functions",
-      // SF doesn't support empty DataFrame. SF's table has to have at least one column,
-      // but Spark DataFrame has no column
-      "SPARK-22951: dropDuplicates on empty dataFrames should produce correct aggregate "
-        + "(whole-stage-codegen off)",
-      "SPARK-22951: dropDuplicates on empty dataFrames should produce correct aggregate "
-        + "(whole-stage-codegen on)",
-      "SPARK-31620: agg with subquery (whole-stage-codegen = true)",
-      "SPARK-31620: agg with subquery (whole-stage-codegen = false)",
-      // SF doesn't support collect_set()
-      "SPARK-31500: collect_set() of BinaryType returns duplicate elements",
-      // disable this test case, re-enable when we have parameters
-      "spark.sql.retainGroupColumns config")
+       )
 }

--- a/src/it/scala/org/apache/spark/sql/SFDataFrameSetOperationsSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDataFrameSetOperationsSuite.scala
@@ -12,35 +12,8 @@ class SFDataFrameSetOperationsSuite
 
   override protected def blackList: Seq[String] =
     Seq(
-      // All test names that are commented pass
-      // "intersect",
-      // "except",
-      // "SPARK-23274: except between two projects without references used in filter",
-      // "except distinct - SQL compliance",
-      // "SPARK-10539: Project should not be pushed down through Intersect or Except",
-      //
-      // Added test for these below with some modifications
-      "union all",
-      "union by name",
-      "except - nullability",
-      "intersect - nullability",
       "SPARK-25368 Incorrect predicate pushdown returns wrong result",
-      "SPARK-17123: Performing set operations that combine non-scala native types",
-      "union by name - check name duplication",
-      "SPARK-10740: handle nondeterministic expressions correctly for set operations",
-      //
-      // Snowflake does not support except all and intersect all
-      "except all",
       "exceptAll - nullability",
-      "intersectAll",
-      "intersectAll - nullability",
-      //
-      // This test just asserts that map function does not work with union
-      "SPARK-19893: cannot run set operations with map type",
-      // TODO: We will need to handle upcasting for columns if their types don't match
-      "union by name - type coercion",
-      // ThunderSnow does not support SQL confs for case sensitivity
-      "union by name - check case sensitivity",
-      // Snowflake does not support UDT
-      "union should union DataFrames with UDTs (SPARK-13410)")
+      "intersectAll - nullability"
+   )
 }

--- a/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFramesSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFramesSuite.scala
@@ -10,35 +10,5 @@ class SFDataFrameWindowFramesSuite
 
   override def spark: SparkSession = getSnowflakeSession()
 
-  override protected def blackList: Seq[String] =
-    Seq(
-      // invoke FIRST/LAST function, skip
-      "rows/range between with empty data frame",
-      "unbounded preceding/following rows between with aggregation",
-      "reverse unbounded preceding/following rows between with aggregation",
-      // SF Window size is no more than 1000, replaced by
-      // TS - rows between should accept int/long values as boundary
-      "rows between should accept int/long values as boundary",
-      // change Exception type, replaced by
-      // TS - range between should accept at most one ORDER BY expression when unbounded
-      "range between should accept at most one ORDER BY expression when unbounded",
-      // change Exception type, replaced by
-      // TS - range between should accept numeric values only when bounded
-      "range between should accept numeric values only when bounded",
-      // SF sliding window frame unsupported for function COUNT, skip
-      "range between should accept int/long values as boundary",
-      // SF cumulative window frame unsupported for function SUM, skip
-      "unbounded preceding/following range between with aggregation",
-      "reverse preceding/following range between with aggregation",
-      // floating point issue, replaced by
-      // TS - sliding rows between with aggregation
-      "sliding rows between with aggregation",
-      // floating point issue, replaced by
-      // TS - reverse sliding rows between with aggregation
-      "reverse sliding rows between with aggregation",
-      // Sliding window frame unsupported for function AVG, skip
-      "sliding range between with aggregation",
-      "reverse sliding range between with aggregation",
-      // Sliding window frame unsupported for function LEAD, skip
-      "SPARK-24033: Analysis Failure of OffsetWindowFunction")
+  override protected def blackList: Seq[String] = Seq.empty
 }

--- a/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFunctionsSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFunctionsSuite.scala
@@ -12,55 +12,11 @@ class SFDataFrameWindowFunctionsSuite
 
   override protected def blackList: Seq[String] =
     Seq(
-      // report SnowflakeSQLException instead of AnalysisException, replaced by
-      // TS - window function should fail if order by clause is not specified
-      "window function should fail if order by clause is not specified",
-      // Double.NaN is not supported, replaced by
       // TS - corr, covar_pop, stddev_pop functions in specific window
       "corr, covar_pop, stddev_pop functions in specific window",
-      // Double.NaN is not supported, replaced by
       // TS - covar_samp, var_samp (variance), stddev_samp (stddev) functions in specific window
       "covar_samp, var_samp (variance), stddev_samp (stddev) functions in specific window",
-      // collect_list and collect_set are not supported, skip
-      "collect_list in ascending ordered window",
-      "collect_list in descending ordered window",
-      "collect_set in window",
-      // SF returns different result of Skewness and Kurtosis, replaced by
-      // TS - skewness and kurtosis functions in window
-      "skewness and kurtosis functions in window",
-      // report SnowflakeSQLException instead of AnalysisException, replaced by
-      // TS - aggregation function on invalid column
-      "aggregation function on invalid column",
-      // numerical aggregate function on string column,
-      // Spark returns null value, but SF reports error, skip
-      "numerical aggregate functions on string column",
-      // SF answer is BigDecimal but not Double, replaced by
-      // TS - statistical functions
-      "statistical functions",
-      // invoke temp view, skip
-      "SPARK-16195 empty over spec",
-      "aggregation and rows between with unbounded + predicate pushdown",
-      "rank functions in unspecific window",
-      "aggregation and range between with unbounded + predicate pushdown",
-      // invoke udaf, skip
-      "window function with udaf",
-      "window function with aggregator",
-      // skip, spark's first and last functions are different than SF's FIRST_VALUE and LAST_VALUE
-      "last/first with ignoreNulls",
-      "last/first on descending ordered window",
-      // invoke struct, skip
-      "SPARK-12989 ExtractWindowExpressions treats alias as regular attribute",
-      // invoke first/last function and struct, skip
-      "SPARK-21258: complex object in combination with spilling",
-      // change Exception names, replaced by
-      // TS - SPARK-24575: Window functions inside WHERE and HAVING clauses
-      "SPARK-24575: Window functions inside WHERE and HAVING clauses",
-      // never spill, skip
-      "Window spill with more than the inMemoryThreshold and spillThreshold",
-      // no number exchanged, replaced by
-      // TS - window functions in multiple selects
-      "window functions in multiple selects",
-      // SF result always be Double, replaced by
       // TS - NaN and -0.0 in window partition keys
-      "NaN and -0.0 in window partition keys")
+      "NaN and -0.0 in window partition keys"
+    )
 }


### PR DESCRIPTION
This PR un-blacklists tests from suites inherited from SnowPark, which had broad blacklisting. Since the Spark Connector is capable of running more of these, almost all of the blacklist test cases can be safely run. The remaining blacklisted tests still fail, and so will need to be investigated separately. 