### PR TITLE
SNOW-222104 Fix a writing issue when table name includes Database or Schema

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationEnv.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationEnv.scala
@@ -48,7 +48,7 @@ trait IntegrationEnv
   /** We read config from this file */
   private final val CONFIG_FILE_VARIABLE = "IT_SNOWFLAKE_CONF"
   private final val CONFIG_JSON_FILE = "snowflake.travis.json"
-  private final val SNOWFLAKE_TEST_ACCOUNT = "SNOWFLAKE_TEST_ACCOUNT"
+  private[snowflake] final val SNOWFLAKE_TEST_ACCOUNT = "SNOWFLAKE_TEST_ACCOUNT"
   protected final val MISSING_PARAM_ERROR =
     "Missing required configuration value: "
 

--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -18,8 +18,10 @@ import scala.util.Random
 class TruncateTableSuite extends IntegrationSuiteBase {
   val normalTable = s"test_table_$randomSuffix"
   val specialTable = s""""test_table_.'!@#$$%^&* $randomSuffix""""
+  val tableNameWithQuote = s""""test_table_\"\"$randomSuffix""""
+
   // This test will test normal table and table name including special characters
-  val tableNames = Array(normalTable, specialTable)
+  val tableNames = Array(normalTable, specialTable, tableNameWithQuote)
 
   lazy val st1 = new StructType(
     Array(

--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -360,7 +360,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
   }
 
   // This test case is used to reproduce/test SNOW-222104
-  // Teh reproduce conditions are:
+  // The reproducing conditions are:
   // 1. Write data frame to a table with OVERWRITE and (usestagingtable=on truncate_table=off (they are default)).
   // 2. table name includes database name and schema name.
   // 3. sfSchema is configured to a different schema

--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -17,11 +17,10 @@ import scala.util.Random
 
 class TruncateTableSuite extends IntegrationSuiteBase {
   val normalTable = s"test_table_$randomSuffix"
-  val specialTable = s""""test_table_.'!@#$$%^&* $randomSuffix""""
-  val tableNameWithQuote = s""""test_table_\"\"$randomSuffix""""
+  val specialTable = s""""test_table_.'!@#$$%^&*"" $randomSuffix""""""
 
   // This test will test normal table and table name including special characters
-  val tableNames = Array(normalTable, specialTable, tableNameWithQuote)
+  val tableNames = Array(normalTable, specialTable)
 
   lazy val st1 = new StructType(
     Array(

--- a/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
@@ -55,6 +55,8 @@ class StageSuite extends IntegrationSuiteBase {
   private val temp_file_name3 = temp_file3.getName
 
   private val test_table_write: String = s"test_table_write_$randomSuffix"
+  private val test_table_write_with_quote: String =
+    s""""test_table_write_$randomSuffix""""
   private val internal_stage_name = s"test_stage_$randomSuffix"
 
   private val largeStringValue = Random.alphanumeric take 1024 mkString ""
@@ -558,6 +560,51 @@ class StageSuite extends IntegrationSuiteBase {
       Utils.runQuery(
         sfOptionsNoTable,
         s"drop table if exists $test_table_large_result"
+      )
+      TestHook.disableTestHook()
+    }
+  }
+
+  // Test Parameters.PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY
+  // This option is internal only, this test case can be removed when
+  // this option is removed.
+  test("test Parameters.PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY") {
+    try {
+      setupLargeResultTable(connectorOptionsNoTable)
+
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", s"$test_table_large_result")
+        .load()
+
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table_write_with_quote)
+        .option(
+          Parameters.PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY,
+          "true"
+        )
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      assert(
+        sparkSession.read
+          .format(SNOWFLAKE_SOURCE_NAME)
+          .options(connectorOptionsNoTable)
+          .option("dbtable", test_table_write_with_quote)
+          .load()
+          .count() == LARGE_TABLE_ROW_COUNT
+      )
+    } finally {
+      Utils.runQuery(
+        connectorOptionsNoTable,
+        s"drop table if exists $test_table_large_result"
+      )
+      Utils.runQuery(
+        connectorOptionsNoTable,
+        s"drop table if exists $test_table_write_with_quote"
       )
       TestHook.disableTestHook()
     }

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -130,9 +130,9 @@ object Parameters {
     "use_exponential_backoff"
   )
   // Internal option to remove (") in stage table name.
-  // It may be removed without any notice in any time.
-  val PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME: String = knownParam(
-    "internal_remove_quote_for_stage_table_name"
+  // This option may be removed without any notice in any time.
+  val PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY: String = knownParam(
+    "internal_staging_table_name_remove_quotes_only"
   )
 
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
@@ -582,8 +582,8 @@ object Parameters {
     def useExponentialBackoff: Boolean = {
       isTrue(parameters.getOrElse(PARAM_USE_EXPONENTIAL_BACKOFF, "false"))
     }
-    def removeQuoteForStageTableName: Boolean = {
-      isTrue(parameters.getOrElse(PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME, "false"))
+    def stagingTableNameRemoveQuotesOnly: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY, "false"))
     }
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -129,6 +129,11 @@ object Parameters {
   val PARAM_USE_EXPONENTIAL_BACKOFF: String = knownParam(
     "use_exponential_backoff"
   )
+  // Internal option to remove (") in stage table name.
+  // It may be removed without any notice in any time.
+  val PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME: String = knownParam(
+    "internal_remove_quote_for_stage_table_name"
+  )
 
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
@@ -576,6 +581,9 @@ object Parameters {
     }
     def useExponentialBackoff: Boolean = {
       isTrue(parameters.getOrElse(PARAM_USE_EXPONENTIAL_BACKOFF, "false"))
+    }
+    def removeQuoteForStageTableName: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME, "false"))
     }
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -325,19 +325,21 @@ private[io] object StageWriter {
 
     if (tableName.contains(".")) {
       // Table name may include DATABASE or SCHEMA.
-      // It is necessary to determine to replace TABLE_NAME only.
-      if (tableName.endsWith("\"")) {
+      // It is necessary to determine and replace TABLE_NAME only.
+      if (tableName.trim.endsWith("\"")) {
         // The table name is quoted.
-        // Split table with last '.' can get the table name
+        // Split table name with last ".\"" can get the table name
         val lastDotQuoteIndex = tableName.lastIndexOf(".\"")
         if (lastDotQuoteIndex > 0) {
+          // There is a database or schema in the table name.
           s"${tableName.substring(0, lastDotQuoteIndex)}.${genTableName()}"
         } else {
+          // The whole table name is quoted.
           genTableName()
         }
       } else {
         // The table name is not quoted.
-        // Split table with last '.' can get the table name
+        // Split table name with last '.' can get the table name
         val lastDotIndex = tableName.lastIndexOf('.')
         s"${tableName.substring(0, lastDotIndex)}.${genTableName()}"
       }

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -160,19 +160,19 @@ class MiscSuite01 extends FunSuite with Matchers {
 
   test("test Parameters.removeQuoteForStageTableName()") {
     // Explicitly set it as true
-    var sfOptions = Map(Parameters.PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME -> "true")
+    var sfOptions = Map(Parameters.PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY -> "true")
     var param = Parameters.MergedParameters(sfOptions)
-    assert(param.removeQuoteForStageTableName)
+    assert(param.stagingTableNameRemoveQuotesOnly)
 
     // Explicitly set it as false
-    sfOptions = Map(Parameters.PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME -> "false")
+    sfOptions = Map(Parameters.PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY -> "false")
     param = Parameters.MergedParameters(sfOptions)
-    assert(!param.removeQuoteForStageTableName)
+    assert(!param.stagingTableNameRemoveQuotesOnly)
 
     // It is false by default.
     sfOptions = Map(Parameters.PARAM_USE_PROXY -> "false")
     param = Parameters.MergedParameters(sfOptions)
-    assert(!param.removeQuoteForStageTableName)
+    assert(!param.stagingTableNameRemoveQuotesOnly)
   }
 
   test("test SnowflakeConnectorUtils.handleS3Exception") {

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -158,6 +158,23 @@ class MiscSuite01 extends FunSuite with Matchers {
     })
   }
 
+  test("test Parameters.removeQuoteForStageTableName()") {
+    // Explicitly set it as true
+    var sfOptions = Map(Parameters.PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME -> "true")
+    var param = Parameters.MergedParameters(sfOptions)
+    assert(param.removeQuoteForStageTableName)
+
+    // Explicitly set it as false
+    sfOptions = Map(Parameters.PARAM_INTERNAL_REMOVE_QUOTE_FOR_STAGE_TABLE_NAME -> "false")
+    param = Parameters.MergedParameters(sfOptions)
+    assert(!param.removeQuoteForStageTableName)
+
+    // It is false by default.
+    sfOptions = Map(Parameters.PARAM_USE_PROXY -> "false")
+    param = Parameters.MergedParameters(sfOptions)
+    assert(!param.removeQuoteForStageTableName)
+  }
+
   test("test SnowflakeConnectorUtils.handleS3Exception") {
     // positive test
     val ex1 = new Exception("test S3Exception",

--- a/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
@@ -35,9 +35,10 @@ class IOSuite extends FunSuite with Matchers {
       ("\"My.Schema\".Table_1", Option("\"My.Schema\".")),
       ("\"My.DB\".\"My.Schema\".Table_1", Option("\"My.DB\".\"My.Schema\".")),
       // abnormal table name with abnormal schema or database name
-      ("\"test_table_.'!@#$%^&* 2611611920364743726\"", None),
+      ("\"test_table_.'!@#$%^&* 2611611920364743726\" ", None),
       ("\"Table.1\"", None),
       ("\"My.Schema\".\"Table.1\"", Option("\"My.Schema\".")),
+      ("\"My.Schema\".\"Table.1\" ", Option("\"My.Schema\".")), // Extra space in the name
       ("\"My.DB\".\"My.Schema\".\"Table.1\"", Option("\"My.DB\".\"My.Schema\".")),
       // mixed
       ("My_Schema.\"Table.1\"", Option("My_Schema.")),

--- a/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
@@ -43,7 +43,15 @@ class IOSuite extends FunSuite with Matchers {
       // mixed
       ("My_Schema.\"Table.1\"", Option("My_Schema.")),
       ("My_DB.\"My.Schema\".\"Table.1\"", Option("My_DB.\"My.Schema\".")),
-      ("\"My.DB\".My_Schema.\"Table.1\"", Option("\"My.DB\".My_Schema."))
+      ("\"My.DB\".My_Schema.\"Table.1\"", Option("\"My.DB\".My_Schema.")),
+      // table name may include QUOTE
+      ("My_Schema.\"Table\"\"1\"", Option("My_Schema.")),
+      ("My\"\"Schema.\"Table\"\"\"\"2\"", Option("My\"\"Schema.")),
+      ("My_DB.\"My.Schema\".\"Table\"\"1\"", Option("My_DB.\"My.Schema\".")),
+      ("My_DB.\"My\"\"Schema\".\"Table\"\"\"\"2\"", Option("My_DB.\"My\"\"Schema\".")),
+      // Below table name is illegal, normal stage table name is returned.
+      ("My_Schema.Table_1\"", None),
+      ("My_Schema.\"Table_1", None)
     )
 
     val debugPrint = true
@@ -54,7 +62,7 @@ class IOSuite extends FunSuite with Matchers {
         assert(stageTableName.startsWith(s"${pair._2.getOrElse("")}$autoGeneratePrefix"))
         if (debugPrint) {
           println(s"${pair._1}  --->  $stageTableName")
-          println("======================================================")
+          println("----------------------------------------------")
         }
       }
     )

--- a/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
@@ -57,32 +57,18 @@ class IOSuite extends FunSuite with Matchers {
       pair => {
         val stagePostfix = "_staging_"
         val tableName = pair._1
-        val removeQuotes = Set(true, false)
-        removeQuotes.foreach(
-          removeQuote => {
-            val stageTableName = StageWriter.getStageTableName(tableName, removeQuote)
-            if (pair._2) {
-              if (removeQuote) {
-                assert(stageTableName.startsWith(
-                  s"${tableName.substring(0, tableName.lastIndexOf("\""))}$stagePostfix".replaceAll("\"", "")))
-              } else {
-                assert(stageTableName.startsWith(
-                  s"${tableName.substring(0, tableName.lastIndexOf("\""))}$stagePostfix"))
-                assert(stageTableName.endsWith("\""))
-              }
-            } else {
-              if (removeQuote) {
-                assert(stageTableName.startsWith(s"${tableName.trim}$stagePostfix".replaceAll("\"", "")))
-              } else {
-                assert(stageTableName.startsWith(s"${tableName.trim}$stagePostfix"))
-              }
-              assert(!stageTableName.endsWith("\""))
-            }
-            if (debugPrint) {
-              println(s"${pair._1} ($removeQuote\t) --->  $stageTableName")
-            }
-          }
-        )
+        val stageTableName = StageWriter.getStageTableName(tableName)
+        if (pair._2) {
+          assert(stageTableName.startsWith(
+            s"${tableName.substring(0, tableName.lastIndexOf("\""))}$stagePostfix"))
+          assert(stageTableName.endsWith("\""))
+        } else {
+          assert(stageTableName.startsWith(s"${tableName.trim}$stagePostfix"))
+          assert(!stageTableName.endsWith("\""))
+        }
+        if (debugPrint) {
+          println(s"${pair._1}  --->  $stageTableName")
+        }
       }
     )
   }

--- a/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2020 Snowflake Computing
+ * Copyright 2015 TouchType Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.snowflake.spark.snowflake.io
+
+import org.scalatest.{FunSuite, Matchers}
+
+class IOSuite extends FunSuite with Matchers {
+
+  test("test generate stage table name") {
+    // Original table name --> database_schema
+    // NOTE: in this context, NORMAL means that the name doesn't include '.'
+    val tableNamePair = Seq (
+      // normal table name
+      ("test_table", None),
+      ("test_table!@#$%^&^", None),
+      // normal table name with normal schema or database
+      ("My_Schema.Table_1", Option("My_Schema.")),
+      ("My_DB.My_Schema.Table_1", Option("My_DB.My_Schema.")),
+      // normal table name with abnormal schema or database name
+      ("\"My.Schema\".Table_1", Option("\"My.Schema\".")),
+      ("\"My.DB\".\"My.Schema\".Table_1", Option("\"My.DB\".\"My.Schema\".")),
+      // abnormal table name with abnormal schema or database name
+      ("\"test_table_.'!@#$%^&* 2611611920364743726\"", None),
+      ("\"Table.1\"", None),
+      ("\"My.Schema\".\"Table.1\"", Option("\"My.Schema\".")),
+      ("\"My.DB\".\"My.Schema\".\"Table.1\"", Option("\"My.DB\".\"My.Schema\".")),
+      // mixed
+      ("My_Schema.\"Table.1\"", Option("My_Schema.")),
+      ("My_DB.\"My.Schema\".\"Table.1\"", Option("My_DB.\"My.Schema\".")),
+      ("\"My.DB\".My_Schema.\"Table.1\"", Option("\"My.DB\".My_Schema."))
+    )
+
+    val debugPrint = true
+    tableNamePair.foreach(
+      pair => {
+        val autoGeneratePrefix = "spark_stage_table_"
+        val stageTableName = StageWriter.getStageTableName(pair._1)
+        assert(stageTableName.startsWith(s"${pair._2.getOrElse("")}$autoGeneratePrefix"))
+        if (debugPrint) {
+          println(s"${pair._1}  --->  $stageTableName")
+          println("======================================================")
+        }
+      }
+    )
+  }
+}

--- a/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/io/IOSuite.scala
@@ -57,18 +57,32 @@ class IOSuite extends FunSuite with Matchers {
       pair => {
         val stagePostfix = "_staging_"
         val tableName = pair._1
-        val stageTableName = StageWriter.getStageTableName(tableName)
-        if (pair._2) {
-          assert(stageTableName.startsWith(
-            s"${tableName.substring(0, tableName.lastIndexOf("\""))}$stagePostfix"))
-          assert(stageTableName.endsWith("\""))
-        } else {
-          assert(stageTableName.startsWith(s"${tableName.trim}$stagePostfix"))
-          assert(!stageTableName.endsWith("\""))
-        }
-        if (debugPrint) {
-          println(s"${pair._1}  --->  $stageTableName")
-        }
+        val removeQuotes = Set(true, false)
+        removeQuotes.foreach(
+          removeQuote => {
+            val stageTableName = StageWriter.getStageTableName(tableName, removeQuote)
+            if (pair._2) {
+              if (removeQuote) {
+                assert(stageTableName.startsWith(
+                  s"${tableName.substring(0, tableName.lastIndexOf("\""))}$stagePostfix".replaceAll("\"", "")))
+              } else {
+                assert(stageTableName.startsWith(
+                  s"${tableName.substring(0, tableName.lastIndexOf("\""))}$stagePostfix"))
+                assert(stageTableName.endsWith("\""))
+              }
+            } else {
+              if (removeQuote) {
+                assert(stageTableName.startsWith(s"${tableName.trim}$stagePostfix".replaceAll("\"", "")))
+              } else {
+                assert(stageTableName.startsWith(s"${tableName.trim}$stagePostfix"))
+              }
+              assert(!stageTableName.endsWith("\""))
+            }
+            if (debugPrint) {
+              println(s"${pair._1} ($removeQuote\t) --->  $stageTableName")
+            }
+          }
+        )
       }
     )
   }


### PR DESCRIPTION
Issue description
============
In the PR 282, all special characters are replaced as 'X' when generating a temp stage table name for writing to snowflake database. But unfortunately, some users have the table name to include database and schema name. If below 4 conditions are satisfied in the same time, the write job will fail.
1. Write data frame to a table with OVERWRITE and (usestagingtable=on truncate_table=off (they are default)).
2. table name includes database name and schema name.
3. sfSchema is configured to a different schema
4. The user has privilege to create stage but doesn't have privilege to create table on sfSchema

Fix
====
There is a basic assumption that the table name must be a valid table name for snowflake,
otherwise create table will fail anyway. The safest way to generate a staging table name is
to add a random postfix to the original table name. And the random postfix only include
common characters [0-9a-zA-Z ]. The database name and schema name are in the leading part,
so they are not affected. For example,
My_DB.My_Schema.MY_TABLE        ==> My_DB.My_Schema.MY_TABLE_staging_XXXXX
"My.DB"."My.Schema"."MY.TABLE"  ==> "My.DB"."My.Schema"."MY.TABLE_staging_XXXXX"

Be careful to handle below special cases:
1. Table name may be quoted or not.
2. There may be white characters in the end.

Below are the unit test table names and the generated stage table names:

test_table  --->  test_table_staging_868568613
test_table!@#$%^&^  --->  test_table!@#$%^&^_staging_1219750424
My_Schema.Table_1  --->  My_Schema.Table_1_staging_1198998292
My_DB.My_Schema.Table_1  --->  My_DB.My_Schema.Table_1_staging_2010887278
"My.Schema".Table_1  --->  "My.Schema".Table_1_staging_1773042307
"My.DB"."My.Schema".Table_1  --->  "My.DB"."My.Schema".Table_1_staging_1457942305
"test_table_.'!@#$%^&* 2611611920364743726"   --->  "test_table_.'!@#$%^&* 2611611920364743726_staging_638657005"
"Table.1"  --->  "Table.1_staging_1242308192"
"My.Schema"."Table.1"  --->  "My.Schema"."Table.1_staging_2049518994"
"My.Schema"."Table.1"   --->  "My.Schema"."Table.1_staging_900935185"
"My.DB"."My.Schema"."Table.1"  --->  "My.DB"."My.Schema"."Table.1_staging_1346640764"
My_Schema."Table.1"  --->  My_Schema."Table.1_staging_451508044"
My_DB."My.Schema"."Table.1"  --->  My_DB."My.Schema"."Table.1_staging_2136103915"
"My.DB".My_Schema."Table.1"  --->  "My.DB".My_Schema."Table.1_staging_2119220707"
My_Schema."Table""1"  --->  My_Schema."Table""1_staging_1395092498"
"My""Schema"."Table""""2"  --->  "My""Schema"."Table""""2_staging_1874852802"
My_DB."My.Schema"."Table""1"  --->  My_DB."My.Schema"."Table""1_staging_1991416482"
My_DB."My""Schema"."Table""""2"  --->  My_DB."My""Schema"."Table""""2_staging_785611724"
My_DB."My""Schema"."Table""2"""  --->  My_DB."My""Schema"."Table""2""_staging_66100706"