### PR TITLE
SNOW-239416 Disable one test case for SC regress test.

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -384,7 +384,10 @@ class TruncateTableSuite extends IntegrationSuiteBase {
   // 2. Configure truncate_table = on and usestagingtable=off can workaround this issue.
   test("write table with different schema") {
     val accountName = System.getenv(SNOWFLAKE_TEST_ACCOUNT)
-    if (accountName == null || accountName.equals("aws")) {
+    val isAWS = accountName == null || accountName.equals("aws")
+    // It is necessary to check extraTestForCoverage because the released SC back-compatibility
+    // regress test for preprod3/QA is on AWS too, but the test schema is not set up there.
+    if (isAWS && extraTestForCoverage) {
       tableNames.foreach(table => {
         println(s"""Test table: "$table"""")
         jdbcUpdate(s"drop table if exists $table")


### PR DESCRIPTION
The test case of "write table with different schema" in
TruncateTableSuite needs special test account configuration to run it.
But the account configuration is not done for preprod3/QA account,
so disable this test case for the released SC back-compatibility
regress test.