### PR TITLE
SNOW-175813 Pushdown coalesce() to snowflake.

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
@@ -14,6 +14,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   Attribute,
   CaseWhen,
   Cast,
+  Coalesce,
   DenseRank,
   Descending,
   Expression,
@@ -135,6 +136,14 @@ private[querygeneration] object MiscStatement {
           case None => EmptySnowflakeSQLStatement()
         }} + ConstantString("END")
 
+      case Coalesce(columns) =>
+        ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(
+            mkStatement(
+              columns.map(convertStatement(_, fields)),
+              ", "
+            )
+          )
 
       case _ => null
     })


### PR DESCRIPTION
1. The original fix is done in https://github.com/snowflakedb/spark-snowflake/pull/253 .
2. The original fix is reverted before releasing SC 2.8.2 in https://github.com/snowflakedb/spark-snowflake/pull/295 .
3. Use “git cherry-pick <hash_code>” to bring back the fix. No merge conflicts happens. Test is PASS.