### PR TITLE
SNOW-177483 Support to pushdown rank()/dense_rank()

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -34,12 +34,14 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   private val test_table_basic: String = s"test_basic_$randomSuffix"
   private val test_table_number = s"test_table_number_$randomSuffix"
   private val test_table_date = s"test_table_date_$randomSuffix"
+  private val test_table_rank = s"test_table_rank_$randomSuffix"
 
   override def afterAll(): Unit = {
     try {
       jdbcUpdate(s"drop table if exists $test_table_basic")
       jdbcUpdate(s"drop table if exists $test_table_number")
       jdbcUpdate(s"drop table if exists $test_table_date")
+      jdbcUpdate(s"drop table if exists $test_table_rank")
     } finally {
       TestHook.disableTestHook()
       super.afterAll()
@@ -317,6 +319,296 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       resultDF,
       expectedResult
     )
+  }
+
+  test("test pushdown WindowExpression: Rank without PARTITION BY") {
+    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
+    if (!params.useCopyUnload) {
+      jdbcUpdate(s"create or replace table $test_table_rank" +
+        s"(state String, bushels_produced Integer)")
+      jdbcUpdate(s"insert into $test_table_rank values" +
+        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+
+      val tmpDF = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", test_table_rank)
+        .load()
+
+      tmpDF.printSchema()
+      tmpDF.createOrReplaceTempView("test_table_rank")
+
+      val resultDF =
+        sparkSession
+          .sql(s"select state, bushels_produced," +
+            " rank() over (order by bushels_produced desc) as total_rank" +
+            " from test_table_rank")
+
+      resultDF.show(10, false)
+
+      val expectedResult = Seq(
+        Row("Iowa", 130, 1),
+        Row("Iowa", 120, 2),
+        Row("Iowa", 120, 2),
+        Row("Kansas", 100, 4),
+        Row("Kansas", 100, 4),
+        Row("Kansas", 90, 6)
+      )
+
+      testPushdown(
+        s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
+           |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
+           |( RANK ()  OVER ( ORDER BY ( "SUBQUERY_0"."BUSHELS_PRODUCED" ) DESC
+           |  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) )
+           |    AS "SUBQUERY_1_COL_2"
+           |FROM ( SELECT * FROM ( $test_table_rank )
+           |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |
+           |""".stripMargin,
+        resultDF,
+        expectedResult
+      )
+    }
+  }
+
+  test("test pushdown WindowExpression: Rank with PARTITION BY") {
+    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
+    if (!params.useCopyUnload) {
+      jdbcUpdate(s"create or replace table $test_table_rank" +
+        s"(state String, bushels_produced Integer)")
+      jdbcUpdate(s"insert into $test_table_rank values" +
+        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+
+      val tmpDF = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", test_table_rank)
+        .load()
+
+      tmpDF.printSchema()
+      tmpDF.createOrReplaceTempView("test_table_rank")
+
+      val resultDF =
+        sparkSession
+          .sql(s"select state, bushels_produced," +
+            " rank() over (partition by state " +
+            "   order by bushels_produced desc) as group_rank" +
+            " from test_table_rank")
+
+      resultDF.show(10, false)
+
+      val expectedResult = Seq(
+        Row("Iowa", 130, 1),
+        Row("Iowa", 120, 2),
+        Row("Iowa", 120, 2),
+        Row("Kansas", 100, 1),
+        Row("Kansas", 100, 1),
+        Row("Kansas", 90, 3)
+      )
+      testPushdown(
+        s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
+           |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
+           |( RANK ()  OVER ( PARTITION BY "SUBQUERY_0"."STATE"
+           |  ORDER BY ( "SUBQUERY_0"."BUSHELS_PRODUCED" ) DESC
+           |  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) )
+           |    AS "SUBQUERY_1_COL_2"
+           |FROM ( SELECT * FROM ( $test_table_rank )
+           |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |
+           |""".stripMargin,
+        resultDF,
+        expectedResult
+      )
+    }
+  }
+
+  test("test pushdown WindowExpression: DenseRank without PARTITION BY") {
+    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
+    if (!params.useCopyUnload) {
+      jdbcUpdate(s"create or replace table $test_table_rank" +
+        s"(state String, bushels_produced Integer)")
+      jdbcUpdate(s"insert into $test_table_rank values" +
+        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+
+      val tmpDF = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", test_table_rank)
+        .load()
+
+      tmpDF.printSchema()
+      tmpDF.createOrReplaceTempView("test_table_rank")
+
+      val resultDF =
+        sparkSession
+          .sql(s"select state, bushels_produced," +
+            " dense_rank() over (order by bushels_produced desc) as total_rank" +
+            " from test_table_rank")
+
+      resultDF.show(10, false)
+
+      val expectedResult = Seq(
+        Row("Iowa", 130, 1),
+        Row("Iowa", 120, 2),
+        Row("Iowa", 120, 2),
+        Row("Kansas", 100, 3),
+        Row("Kansas", 100, 3),
+        Row("Kansas", 90, 4)
+      )
+
+      testPushdown(
+        s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
+           |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
+           |( DENSE_RANK ()  OVER ( ORDER BY ( "SUBQUERY_0"."BUSHELS_PRODUCED" ) DESC
+           |  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) )
+           |    AS "SUBQUERY_1_COL_2"
+           |FROM ( SELECT * FROM ( $test_table_rank )
+           |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |
+           |""".stripMargin,
+        resultDF,
+        expectedResult
+      )
+    }
+  }
+
+  test("test pushdown WindowExpression: DenseRank with PARTITION BY") {
+    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
+    if (!params.useCopyUnload) {
+      jdbcUpdate(s"create or replace table $test_table_rank" +
+        s"(state String, bushels_produced Integer)")
+      jdbcUpdate(s"insert into $test_table_rank values" +
+        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+
+      val tmpDF = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", test_table_rank)
+        .load()
+
+      tmpDF.printSchema()
+      tmpDF.createOrReplaceTempView("test_table_rank")
+
+      val resultDF =
+        sparkSession
+          .sql(s"select state, bushels_produced," +
+            " dense_rank() over (partition by state " +
+            "   order by bushels_produced desc) as group_rank" +
+            " from test_table_rank")
+
+      resultDF.show(10, false)
+
+      val expectedResult = Seq(
+        Row("Iowa", 130, 1),
+        Row("Iowa", 120, 2),
+        Row("Iowa", 120, 2),
+        Row("Kansas", 100, 1),
+        Row("Kansas", 100, 1),
+        Row("Kansas", 90, 2)
+      )
+      testPushdown(
+        s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
+           |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
+           |( DENSE_RANK ()  OVER ( PARTITION BY "SUBQUERY_0"."STATE"
+           |  ORDER BY ( "SUBQUERY_0"."BUSHELS_PRODUCED" ) DESC
+           |  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) )
+           |    AS "SUBQUERY_1_COL_2"
+           |FROM ( SELECT * FROM ( $test_table_rank )
+           |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |
+           |""".stripMargin,
+        resultDF,
+        expectedResult
+      )
+    }
+  }
+
+  /*
+   * PercentRank can't be pushdown to snowflake, because Snowflake's percent_rank only
+   * support window frame type: RANGE. But, PercentRank in Spark only supports window
+   * frame type: ROWS. If a window frame is not specified, a default ROWS window frame
+   * is added by spark.
+   * https://databricks.com/blog/2015/07/15/introducing-window-functions-in-spark-sql.html
+   *
+   * Doc on Snowflake:
+   * PERCENT_RANK supports range-based cumulative window frames,
+   * but not other types of window frames.
+   * https://docs.snowflake.com/en/sql-reference/functions/percent_rank.html
+   */
+  ignore("test pushdown WindowExpression: PercentRank without PARTITION BY") {
+    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
+    if (!params.useCopyUnload) {
+      jdbcUpdate(s"create or replace table $test_table_rank" +
+        s"(state String, bushels_produced Integer)")
+      jdbcUpdate(s"insert into $test_table_rank values" +
+        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+
+      val tmpDF = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", test_table_rank)
+        .load()
+
+      tmpDF.printSchema()
+      tmpDF.createOrReplaceTempView("test_table_rank")
+
+    /*
+     * With useRangeWindow = true, spark raises below exception.
+     *   Window Frame specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())
+     *   must match the required frame
+     *   specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())
+     *
+     * With useRangeWindow = false, snowflake raises below exception.
+     *   SQL compilation error: error line 1 at position 442
+     *   Cumulative window frame unsupported for function PERCENT_RANK
+     */
+      val useRangeWindow = false
+      val resultDF = if (useRangeWindow) {
+        sparkSession
+          .sql(s"select state, bushels_produced," +
+            " percent_rank() over" +
+            "  ( order by bushels_produced desc" +
+            "    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)" +
+            "  as total_rank" +
+            " from test_table_rank")
+      } else {
+        sparkSession
+          .sql(s"select state, bushels_produced," +
+            " percent_rank() over" +
+            "  ( order by bushels_produced desc)" +
+            "  as total_rank" +
+            " from test_table_rank")
+      }
+      resultDF.show(10, false)
+
+      val expectedResult = Seq(
+        Row("Iowa", 130, 0.0),
+        Row("Iowa", 120, 0.2),
+        Row("Iowa", 120, 0.2),
+        Row("Kansas", 100, 0.6),
+        Row("Kansas", 100, 0.6),
+        Row("Kansas", 90, 1.0)
+      )
+
+      testPushdown(
+        s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
+           |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
+           |( PERCENT__RANK ()  OVER ( ORDER BY ( "SUBQUERY_0"."BUSHELS_PRODUCED" ) DESC
+           |  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) )
+           |    AS "SUBQUERY_1_COL_2"
+           |FROM ( SELECT * FROM ( $test_table_rank )
+           |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |
+           |""".stripMargin,
+        resultDF,
+        expectedResult, false, true
+      )
+    }
   }
 
   override def beforeEach(): Unit = {

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -322,40 +322,49 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("test pushdown WindowExpression: Rank without PARTITION BY") {
-    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
-    if (!params.useCopyUnload) {
-      jdbcUpdate(s"create or replace table $test_table_rank" +
-        s"(state String, bushels_produced Integer)")
-      jdbcUpdate(s"insert into $test_table_rank values" +
-        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
-        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+    jdbcUpdate(s"create or replace table $test_table_rank" +
+      s"(state String, bushels_produced Integer)")
+    jdbcUpdate(s"insert into $test_table_rank values" +
+      s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+      s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
 
-      val tmpDF = sparkSession.read
-        .format(SNOWFLAKE_SOURCE_NAME)
-        .options(thisConnectorOptionsNoTable)
-        .option("dbtable", test_table_rank)
-        .load()
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_rank)
+      .load()
 
-      tmpDF.printSchema()
-      tmpDF.createOrReplaceTempView("test_table_rank")
+    tmpDF.printSchema()
+    tmpDF.createOrReplaceTempView("test_table_rank")
 
-      val resultDF =
-        sparkSession
-          .sql(s"select state, bushels_produced," +
-            " rank() over (order by bushels_produced desc) as total_rank" +
-            " from test_table_rank")
+    val resultDF =
+      sparkSession
+        .sql(s"select state, bushels_produced," +
+          " rank() over (order by bushels_produced desc) as total_rank" +
+          " from test_table_rank")
 
-      resultDF.show(10, false)
+    resultDF.show(10, false)
 
-      val expectedResult = Seq(
-        Row("Iowa", 130, 1),
-        Row("Iowa", 120, 2),
-        Row("Iowa", 120, 2),
-        Row("Kansas", 100, 4),
-        Row("Kansas", 100, 4),
-        Row("Kansas", 90, 6)
+    val expectedResult = Seq(
+      Row("Iowa", 130, 1),
+      Row("Iowa", 120, 2),
+      Row("Iowa", 120, 2),
+      Row("Kansas", 100, 4),
+      Row("Kansas", 100, 4),
+      Row("Kansas", 90, 6)
+    )
+
+    if (params.useCopyUnload) {
+      // COPY UNLOAD doesn't support rank()/dense_rank(). Refer to SNOW-177604
+      // The COPY UNLOAD supported function list can be found at
+      // https://docs.snowflake.com/en/user-guide/data-load-transform.html#supported-functions
+      testPushdown(
+        s"""SELECT * FROM ( $test_table_rank ) AS "SF_CONNECTOR_QUERY_ALIAS"
+           |""".stripMargin,
+        resultDF,
+        expectedResult
       )
-
+    } else {
       testPushdown(
         s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
            |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
@@ -364,7 +373,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
            |    AS "SUBQUERY_1_COL_2"
            |FROM ( SELECT * FROM ( $test_table_rank )
            |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-           |
            |""".stripMargin,
         resultDF,
         expectedResult
@@ -373,40 +381,50 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("test pushdown WindowExpression: Rank with PARTITION BY") {
-    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
-    if (!params.useCopyUnload) {
-      jdbcUpdate(s"create or replace table $test_table_rank" +
-        s"(state String, bushels_produced Integer)")
-      jdbcUpdate(s"insert into $test_table_rank values" +
-        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
-        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+    jdbcUpdate(s"create or replace table $test_table_rank" +
+      s"(state String, bushels_produced Integer)")
+    jdbcUpdate(s"insert into $test_table_rank values" +
+      s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+      s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
 
-      val tmpDF = sparkSession.read
-        .format(SNOWFLAKE_SOURCE_NAME)
-        .options(thisConnectorOptionsNoTable)
-        .option("dbtable", test_table_rank)
-        .load()
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_rank)
+      .load()
 
-      tmpDF.printSchema()
-      tmpDF.createOrReplaceTempView("test_table_rank")
+    tmpDF.printSchema()
+    tmpDF.createOrReplaceTempView("test_table_rank")
 
-      val resultDF =
-        sparkSession
-          .sql(s"select state, bushels_produced," +
-            " rank() over (partition by state " +
-            "   order by bushels_produced desc) as group_rank" +
-            " from test_table_rank")
+    val resultDF =
+      sparkSession
+        .sql(s"select state, bushels_produced," +
+          " rank() over (partition by state " +
+          "   order by bushels_produced desc) as group_rank" +
+          " from test_table_rank")
 
-      resultDF.show(10, false)
+    resultDF.show(10, false)
 
-      val expectedResult = Seq(
-        Row("Iowa", 130, 1),
-        Row("Iowa", 120, 2),
-        Row("Iowa", 120, 2),
-        Row("Kansas", 100, 1),
-        Row("Kansas", 100, 1),
-        Row("Kansas", 90, 3)
+    val expectedResult = Seq(
+      Row("Iowa", 130, 1),
+      Row("Iowa", 120, 2),
+      Row("Iowa", 120, 2),
+      Row("Kansas", 100, 1),
+      Row("Kansas", 100, 1),
+      Row("Kansas", 90, 3)
+    )
+
+    if (params.useCopyUnload) {
+      // COPY UNLOAD doesn't support rank()/dense_rank(). Refer to SNOW-177604
+      // The COPY UNLOAD supported function list can be found at
+      // https://docs.snowflake.com/en/user-guide/data-load-transform.html#supported-functions
+      testPushdown(
+        s"""SELECT * FROM ( $test_table_rank ) AS "SF_CONNECTOR_QUERY_ALIAS"
+           |""".stripMargin,
+        resultDF,
+        expectedResult
       )
+    } else {
       testPushdown(
         s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
            |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
@@ -416,7 +434,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
            |    AS "SUBQUERY_1_COL_2"
            |FROM ( SELECT * FROM ( $test_table_rank )
            |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-           |
            |""".stripMargin,
         resultDF,
         expectedResult
@@ -425,40 +442,49 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("test pushdown WindowExpression: DenseRank without PARTITION BY") {
-    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
-    if (!params.useCopyUnload) {
-      jdbcUpdate(s"create or replace table $test_table_rank" +
-        s"(state String, bushels_produced Integer)")
-      jdbcUpdate(s"insert into $test_table_rank values" +
-        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
-        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+    jdbcUpdate(s"create or replace table $test_table_rank" +
+      s"(state String, bushels_produced Integer)")
+    jdbcUpdate(s"insert into $test_table_rank values" +
+      s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+      s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
 
-      val tmpDF = sparkSession.read
-        .format(SNOWFLAKE_SOURCE_NAME)
-        .options(thisConnectorOptionsNoTable)
-        .option("dbtable", test_table_rank)
-        .load()
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_rank)
+      .load()
 
-      tmpDF.printSchema()
-      tmpDF.createOrReplaceTempView("test_table_rank")
+    tmpDF.printSchema()
+    tmpDF.createOrReplaceTempView("test_table_rank")
 
-      val resultDF =
-        sparkSession
-          .sql(s"select state, bushels_produced," +
-            " dense_rank() over (order by bushels_produced desc) as total_rank" +
-            " from test_table_rank")
+    val resultDF =
+      sparkSession
+        .sql(s"select state, bushels_produced," +
+          " dense_rank() over (order by bushels_produced desc) as total_rank" +
+          " from test_table_rank")
 
-      resultDF.show(10, false)
+    resultDF.show(10, false)
 
-      val expectedResult = Seq(
-        Row("Iowa", 130, 1),
-        Row("Iowa", 120, 2),
-        Row("Iowa", 120, 2),
-        Row("Kansas", 100, 3),
-        Row("Kansas", 100, 3),
-        Row("Kansas", 90, 4)
+    val expectedResult = Seq(
+      Row("Iowa", 130, 1),
+      Row("Iowa", 120, 2),
+      Row("Iowa", 120, 2),
+      Row("Kansas", 100, 3),
+      Row("Kansas", 100, 3),
+      Row("Kansas", 90, 4)
+    )
+
+    if (params.useCopyUnload) {
+      // COPY UNLOAD doesn't support rank()/dense_rank(). Refer to SNOW-177604
+      // The COPY UNLOAD supported function list can be found at
+      // https://docs.snowflake.com/en/user-guide/data-load-transform.html#supported-functions
+      testPushdown(
+        s"""SELECT * FROM ( $test_table_rank ) AS "SF_CONNECTOR_QUERY_ALIAS"
+           |""".stripMargin,
+        resultDF,
+        expectedResult
       )
-
+    } else {
       testPushdown(
         s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
            |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
@@ -467,7 +493,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
            |    AS "SUBQUERY_1_COL_2"
            |FROM ( SELECT * FROM ( $test_table_rank )
            |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-           |
            |""".stripMargin,
         resultDF,
         expectedResult
@@ -476,40 +501,50 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("test pushdown WindowExpression: DenseRank with PARTITION BY") {
-    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
-    if (!params.useCopyUnload) {
-      jdbcUpdate(s"create or replace table $test_table_rank" +
-        s"(state String, bushels_produced Integer)")
-      jdbcUpdate(s"insert into $test_table_rank values" +
-        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
-        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
+    jdbcUpdate(s"create or replace table $test_table_rank" +
+      s"(state String, bushels_produced Integer)")
+    jdbcUpdate(s"insert into $test_table_rank values" +
+      s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
+      s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
 
-      val tmpDF = sparkSession.read
-        .format(SNOWFLAKE_SOURCE_NAME)
-        .options(thisConnectorOptionsNoTable)
-        .option("dbtable", test_table_rank)
-        .load()
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_rank)
+      .load()
 
-      tmpDF.printSchema()
-      tmpDF.createOrReplaceTempView("test_table_rank")
+    tmpDF.printSchema()
+    tmpDF.createOrReplaceTempView("test_table_rank")
 
-      val resultDF =
-        sparkSession
-          .sql(s"select state, bushels_produced," +
-            " dense_rank() over (partition by state " +
-            "   order by bushels_produced desc) as group_rank" +
-            " from test_table_rank")
+    val resultDF =
+      sparkSession
+        .sql(s"select state, bushels_produced," +
+          " dense_rank() over (partition by state " +
+          "   order by bushels_produced desc) as group_rank" +
+          " from test_table_rank")
 
-      resultDF.show(10, false)
+    resultDF.show(10, false)
 
-      val expectedResult = Seq(
-        Row("Iowa", 130, 1),
-        Row("Iowa", 120, 2),
-        Row("Iowa", 120, 2),
-        Row("Kansas", 100, 1),
-        Row("Kansas", 100, 1),
-        Row("Kansas", 90, 2)
+    val expectedResult = Seq(
+      Row("Iowa", 130, 1),
+      Row("Iowa", 120, 2),
+      Row("Iowa", 120, 2),
+      Row("Kansas", 100, 1),
+      Row("Kansas", 100, 1),
+      Row("Kansas", 90, 2)
+    )
+
+    if (params.useCopyUnload) {
+      // COPY UNLOAD doesn't support rank()/dense_rank(). Refer to SNOW-177604
+      // The COPY UNLOAD supported function list can be found at
+      // https://docs.snowflake.com/en/user-guide/data-load-transform.html#supported-functions
+      testPushdown(
+        s"""SELECT * FROM ( $test_table_rank ) AS "SF_CONNECTOR_QUERY_ALIAS"
+           |""".stripMargin,
+        resultDF,
+        expectedResult
       )
+    } else {
       testPushdown(
         s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
            |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
@@ -523,90 +558,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
            |""".stripMargin,
         resultDF,
         expectedResult
-      )
-    }
-  }
-
-  /*
-   * PercentRank can't be pushdown to snowflake, because Snowflake's percent_rank only
-   * support window frame type: RANGE. But, PercentRank in Spark only supports window
-   * frame type: ROWS. If a window frame is not specified, a default ROWS window frame
-   * is added by spark.
-   * https://databricks.com/blog/2015/07/15/introducing-window-functions-in-spark-sql.html
-   *
-   * Doc on Snowflake:
-   * PERCENT_RANK supports range-based cumulative window frames,
-   * but not other types of window frames.
-   * https://docs.snowflake.com/en/sql-reference/functions/percent_rank.html
-   */
-  ignore("test pushdown WindowExpression: PercentRank without PARTITION BY") {
-    // There is bug to execute rank()/dense_rank() with COPY UNLOAD: SNOW-177604
-    if (!params.useCopyUnload) {
-      jdbcUpdate(s"create or replace table $test_table_rank" +
-        s"(state String, bushels_produced Integer)")
-      jdbcUpdate(s"insert into $test_table_rank values" +
-        s"('Iowa', 130), ('Iowa', 120), ('Iowa', 120)," +
-        s"('Kansas', 100), ('Kansas', 100), ('Kansas', 90)")
-
-      val tmpDF = sparkSession.read
-        .format(SNOWFLAKE_SOURCE_NAME)
-        .options(thisConnectorOptionsNoTable)
-        .option("dbtable", test_table_rank)
-        .load()
-
-      tmpDF.printSchema()
-      tmpDF.createOrReplaceTempView("test_table_rank")
-
-    /*
-     * With useRangeWindow = true, spark raises below exception.
-     *   Window Frame specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())
-     *   must match the required frame
-     *   specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())
-     *
-     * With useRangeWindow = false, snowflake raises below exception.
-     *   SQL compilation error: error line 1 at position 442
-     *   Cumulative window frame unsupported for function PERCENT_RANK
-     */
-      val useRangeWindow = false
-      val resultDF = if (useRangeWindow) {
-        sparkSession
-          .sql(s"select state, bushels_produced," +
-            " percent_rank() over" +
-            "  ( order by bushels_produced desc" +
-            "    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)" +
-            "  as total_rank" +
-            " from test_table_rank")
-      } else {
-        sparkSession
-          .sql(s"select state, bushels_produced," +
-            " percent_rank() over" +
-            "  ( order by bushels_produced desc)" +
-            "  as total_rank" +
-            " from test_table_rank")
-      }
-      resultDF.show(10, false)
-
-      val expectedResult = Seq(
-        Row("Iowa", 130, 0.0),
-        Row("Iowa", 120, 0.2),
-        Row("Iowa", 120, 0.2),
-        Row("Kansas", 100, 0.6),
-        Row("Kansas", 100, 0.6),
-        Row("Kansas", 90, 1.0)
-      )
-
-      testPushdown(
-        s"""SELECT ( "SUBQUERY_0"."STATE" ) AS "SUBQUERY_1_COL_0" ,
-           |( "SUBQUERY_0"."BUSHELS_PRODUCED" ) AS "SUBQUERY_1_COL_1" ,
-           |( PERCENT__RANK ()  OVER ( ORDER BY ( "SUBQUERY_0"."BUSHELS_PRODUCED" ) DESC
-           |  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) )
-           |    AS "SUBQUERY_1_COL_2"
-           |FROM ( SELECT * FROM ( $test_table_rank )
-           |  AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-           |
-           |""".stripMargin,
-        resultDF,
-        expectedResult, false, true
       )
     }
   }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/WindowStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/WindowStatement.scala
@@ -34,7 +34,7 @@ private[querygeneration] object WindowStatement {
     val fields = expAttr._2
 
     Option(expr match {
-      // Handle Window Expression. (It is moved from MiscStatement)
+      // Handle Window Expression.
       case WindowExpression(func, spec) =>
         func match {
           // These functions in Snowflake support a window frame.
@@ -59,7 +59,7 @@ private[querygeneration] object WindowStatement {
       case _: RowNumber | _: Rank | _: DenseRank =>
         ConstantString(expr.prettyName.toUpperCase) + "()"
 
-      // Until July 21 2020, PercentRank can't be pushdown to snowflake.
+      // PercentRank can't be pushdown to snowflake because:
       //   1. Snowflake's percent_rank only supports window frame type: RANGE.
       //   2. Spark's PercentRank only supports window frame type: ROWS
       case _: PercentRank => null
@@ -68,7 +68,7 @@ private[querygeneration] object WindowStatement {
     })
   }
 
-  // Handle window block. (It is moved from MiscStatement)
+  // Handle window block.
   private final def windowBlock(
                                  spec: WindowSpecDefinition,
                                  fields: Seq[Attribute],

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/WindowStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/WindowStatement.scala
@@ -3,8 +3,13 @@ package net.snowflake.spark.snowflake.pushdowns.querygeneration
 import net.snowflake.spark.snowflake._
 import org.apache.spark.sql.catalyst.expressions.{
   Attribute,
+  DenseRank,
   Expression,
-  RowNumber
+  PercentRank,
+  Rank,
+  RowNumber,
+  WindowExpression,
+  WindowSpecDefinition
 }
 
 /**
@@ -26,11 +31,70 @@ private[querygeneration] object WindowStatement {
     expAttr: (Expression, Seq[Attribute])
   ): Option[SnowflakeSQLStatement] = {
     val expr = expAttr._1
+    val fields = expAttr._2
 
     Option(expr match {
-      case _: RowNumber => ConstantString(expr.prettyName.toUpperCase) + "()"
+      // Handle Window Expression. (It is moved from MiscStatement)
+      case WindowExpression(func, spec) =>
+        func match {
+          // These functions in Snowflake support a window frame.
+          // Note that pushdown for these may or may not yet be supported in the connector.
+          case _: Rank | _: DenseRank | _: PercentRank =>
+            convertStatement(func, fields) + " OVER " + windowBlock(
+              spec,
+              fields,
+              useWindowFrame = true
+            )
+
+          // These do not.
+          case _ =>
+            convertStatement(func, fields) + " OVER " + windowBlock(
+              spec,
+              fields,
+              useWindowFrame = false
+            )
+        }
+
+      // Handle supported window function
+      case _: RowNumber | _: Rank | _: DenseRank =>
+        ConstantString(expr.prettyName.toUpperCase) + "()"
+
+      // Until July 21 2020, PercentRank can't be pushdown to snowflake.
+      //   1. Snowflake's percent_rank only supports window frame type: RANGE.
+      //   2. Spark's PercentRank only supports window frame type: ROWS
+      case _: PercentRank => null
 
       case _ => null
     })
   }
+
+  // Handle window block. (It is moved from MiscStatement)
+  private final def windowBlock(
+                                 spec: WindowSpecDefinition,
+                                 fields: Seq[Attribute],
+                                 useWindowFrame: Boolean
+                               ): SnowflakeSQLStatement = {
+    val partitionBy =
+      if (spec.partitionSpec.isEmpty) {
+        EmptySnowflakeSQLStatement()
+      } else {
+        ConstantString("PARTITION BY") +
+          mkStatement(spec.partitionSpec.map(convertStatement(_, fields)), ",")
+      }
+
+    val orderBy =
+      if (spec.orderSpec.isEmpty) {
+        EmptySnowflakeSQLStatement()
+      } else {
+        ConstantString("ORDER BY") +
+          mkStatement(spec.orderSpec.map(convertStatement(_, fields)), ",")
+      }
+
+    val fromTo =
+      if (!useWindowFrame || spec.orderSpec.isEmpty) ""
+      else " " + spec.frameSpecification.sql
+
+    blockStatement(partitionBy + orderBy + fromTo)
+  }
+
 }


### PR DESCRIPTION
Snowflake supports rank()/dense_rank() for SELECT query, but doesn’t support them in reading with COPY UNLOAD.
The pushdown analysis is performed in plan generation, it is impossible to know whether use_copy_unload is true or false, so they are pushdown anyway.
If use_copy_unload = true (default is false), the COPY UNLOAD fails. But, SC will retry without pushdown them. So, the job will succeed in the end.
PS: The COPY UNLOAD supported function list can be found at https://docs.snowflake.com/en/user-guide/data-load-transform.html#supported-functions

1. The original fix is done in https://github.com/snowflakedb/spark-snowflake/pull/255
2. The original fix is reverted before releasing SC 2.8.2 in https://github.com/snowflakedb/spark-snowflake/pull/295
3. Use “git cherry-pick <hash_code>” to bring back the fix. The production code is auto-merged. Do some manual merge for test case.
4. There are 2 comments in this PR.
    a. The first one is generated by  “git cherry-pick <hash_code>”.
    b. The second commits is to update the test cases. The original test cases only run for use_copy_unload = false. Update them to run for use_copy_unload = true. If use_copy_unload is true, the reading must be successful and the result to be the same.