### PR TITLE
SNOW-241656 Enhance test function testPushdown().

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -18,6 +18,7 @@
 package net.snowflake.spark.snowflake
 
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
+import net.snowflake.spark.snowflake.pushdowns.SnowflakeStrategy
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
@@ -46,11 +47,11 @@ trait IntegrationSuiteBase
     * Verify that the pushdown was done by looking at the generated SQL,
     * and check the results are as expected
     */
-  def testPushdown(reference: String,
-                   result: DataFrame,
-                   expectedAnswer: Seq[Row],
-                   bypass: Boolean = false,
-                   printSqlText: Boolean = false): Unit = {
+  def testPushdownBasic(reference: String,
+                        result: DataFrame,
+                        expectedAnswer: Seq[Row],
+                        bypass: Boolean = false,
+                        printSqlText: Boolean = false): Unit = {
 
     // Verify the query issued is what we expect
     checkAnswer(result, expectedAnswer)
@@ -67,6 +68,43 @@ trait IntegrationSuiteBase
           .toLowerCase
       )
     }
+  }
+
+  /**
+    * Verify that the pushdown was done by looking at the generated SQL,
+    * and check the results are as expected.
+    * It also reads the DataFrame after disabling the pushdown.
+    * The test result should be as expected too.
+    */
+  def testPushdown(reference: String,
+                   result: DataFrame,
+                   expectedAnswer: Seq[Row],
+                   bypass: Boolean = false,
+                   printSqlText: Boolean = false,
+                   testPushdownOff: Boolean = true): Unit = {
+    testPushdownBasic(reference, result, expectedAnswer, bypass, printSqlText)
+
+    // Disable pushdown and rerun the dataframe, the result should match
+    if (testPushdownOff && isPushdownEnabled(result.sparkSession)) {
+      try {
+        SnowflakeConnectorUtils.disablePushdownSession(result.sparkSession)
+        // Re-read the DataFrame but don't check the executed query text.
+        // 'result' has been compiled, so spark plan with pushdown could have been cached.
+        // So, use 'result.select("*")' to make sure snowflake pushdown is not used.
+        testPushdownBasic(reference, result.select("*"), expectedAnswer, bypass = true, printSqlText)
+      } catch {
+        case th: Throwable => {
+          println(s"Fail to read DataFrame with pushdown disabled. ${th.getMessage}")
+          throw th
+        }
+      } finally {
+        SnowflakeConnectorUtils.enablePushdownSession(result.sparkSession)
+      }
+    }
+  }
+
+  private def isPushdownEnabled(session: SparkSession): Boolean = {
+    session.experimental.extraStrategies.exists( s => s.isInstanceOf[SnowflakeStrategy])
   }
 
   /**

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -47,11 +47,11 @@ trait IntegrationSuiteBase
     * Verify that the pushdown was done by looking at the generated SQL,
     * and check the results are as expected
     */
-  def testPushdownBasic(reference: String,
-                        result: DataFrame,
-                        expectedAnswer: Seq[Row],
-                        bypass: Boolean = false,
-                        printSqlText: Boolean = false): Unit = {
+  private def testPushdownBasic(reference: String,
+                                result: DataFrame,
+                                expectedAnswer: Seq[Row],
+                                bypass: Boolean = false,
+                                printSqlText: Boolean = false): Unit = {
 
     // Verify the query issued is what we expect
     checkAnswer(result, expectedAnswer)

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
@@ -659,7 +659,8 @@ class PushdownEnhancement01 extends IntegrationSuiteBase {
          |)
          |""".stripMargin,
       result,
-      expectedResult
+      expectedResult,
+      testPushdownOff = false
     )
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
@@ -105,7 +105,8 @@ class PushdownEnhancement01 extends IntegrationSuiteBase {
          |FROM ( SELECT * FROM ( $test_table_length ) AS
          |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" """.stripMargin,
       result,
-      expectedResult
+      expectedResult,
+      testPushdownOff = false
     )
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/SimpleNewPushdownIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SimpleNewPushdownIntegrationSuite.scala
@@ -439,7 +439,7 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
                     |AS "SUBQUERY_1_COL_1" FROM ( SELECT * FROM (
                     |$test_table2 ) AS "SF_CONNECTOR_QUERY_ALIAS" )
                     |AS "SUBQUERY_0"
-      """.stripMargin, result, expResultSet, disablePushDown)
+      """.stripMargin, result, expResultSet, disablePushDown, testPushdownOff = false)
 
     // Set back.
     if (disablePushDown) {


### PR DESCRIPTION
In spark connector pushdown test,  testPushdown() is commonly used. It will
1. Read the DataFrame from snowflake.
2. Compare the result to be equal to the expected result.
3. The executed query text must match the expected query text.

The read result must the be the same even if the pushdown is disabled. So, add below 2 extra steps for this test function.
1. Disable pushdown and read the DataFrame again.
2. Compare the read result to be equal to the expected result. (Don’t check executed the query text).

This enhancement has found 3 test cases failure. After investigation, they are not actual Spark connector issues. So disable the extra steps for them. Explain them in file changes.