### PR TITLE
SNOW-179329 Support pushdown for DateSub

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -2,8 +2,10 @@ package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
 import net.snowflake.spark.snowflake.{ConstantString, SnowflakeSQLStatement}
 import org.apache.spark.sql.catalyst.expressions.{
+  AddMonths,
   Attribute,
   DateAdd,
+  DateSub,
   Expression,
   Month,
   Quarter,
@@ -14,6 +16,11 @@ import org.apache.spark.sql.catalyst.expressions.{
 
 /** Extractor for boolean expressions (return true or false). */
 private[querygeneration] object DateStatement {
+  // DateAdd's pretty name in Spark is "date_add",
+  // the counterpart's name in SF is "DATEADD".
+  // And the syntax is some different.
+  val SNOWFLAKE_DATEADD = "DATEADD"
+
   def unapply(
     expAttr: (Expression, Seq[Attribute])
   ): Option[SnowflakeSQLStatement] = {
@@ -22,8 +29,27 @@ private[querygeneration] object DateStatement {
 
     Option(expr match {
       case DateAdd(startDate, days) =>
-        ConstantString("DATEADD(day,") + convertStatement(days, fields) + "," +
-          convertStatement(startDate, fields) + ")"
+        ConstantString(SNOWFLAKE_DATEADD) +
+          blockStatement(
+            ConstantString("day,") +
+              convertStatement(days, fields) + "," +
+              convertStatement(startDate, fields)
+          )
+
+      // Snowflake has no direct DateSub function,
+      // it is pushdown by DATEADD with negative days
+      case DateSub(startDate, days) =>
+        ConstantString(SNOWFLAKE_DATEADD) +
+          blockStatement(
+            ConstantString("day, (0 - (") +
+              convertStatement(days, fields) + ") )," +
+              convertStatement(startDate, fields)
+          )
+
+      case AddMonths(startDate, days) =>
+        ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(convertStatement(startDate, fields) + "," +
+            convertStatement(days, fields))
 
       case _: Month | _: Quarter | _: Year |
            _: TruncDate | _: TruncTimestamp =>


### PR DESCRIPTION
Support pushdown for DateSub.
1. SC has already support pushdown fo DateAdd. But no test case is added to test it. Add test case to cover DateAdd().
2. Spark supports DateSub(), Snowflake has NO direct function for this. But Snowflake’s DateAdd() DOES support DateAdd() with negative value which is equivalent to DataSub(). So it can be pushdown too.
3. NOTE: AddMonth() can NOT be pushdown. Both Spark and Snowflake supports AddMonth(). But it can’t be pushdown because there is some different
a. For snowflake ADD_MONTHS: Adds or subtracts a specified number of months to a date or timestamp, preserving the end-of-month information.https://docs.snowflake.com/en/sql-reference/functions/add_months.html
b. For spark ADD_MONTHS:  The behavior for spark 2.3/2.4 and spark 3.0 is different. Spark 2.3/2.4 is preserving the end-of-month information. But Spark 3.0 isn’t. For example, On spark 2.3/2.4, "2015-02-28" +1 month -> "2015-03-31"; On spark 3.0, "2015-02-28" +1 month -> "2015-03-28"

Change history:
1. The original fix is done in  https://github.com/snowflakedb/spark-snowflake/pull/261. It supports the pushdown for both DateSub() and AddMonths().
2. The original fix is reverted before releasing SC 2.8.2 in https://github.com/snowflakedb/spark-snowflake/pull/295. .
3. Use “git cherry-pick <hash_code>” to bring back the fix. The production code is auto-merged. Do some manual merge for test case.
4. There are 2 comments in this PR. 
a. The first is generated by  “git cherry-pick <hash_code>”.
b. The second commit removes the pushdown for AddMonths() and add more more test to make sure DataAdd/DateSub to work well with the last day on Feb for leap and non-leap year.