### PR TITLE
SNOW-262080 use fully qualified name when detecting table existence

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -1981,7 +1981,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
       // drop table in this schema
       jdbcUpdate(s"drop table if exists $test_table_write")
 
-      // Write with "internal_use_full_qualified_name" = "false"
+      // Staging table with "internal_use_full_qualified_name" = "false"
       assertThrows[Exception]({
         tmpDF.write
           .format(SNOWFLAKE_SOURCE_NAME)
@@ -1992,7 +1992,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
           .save()
       })
 
-      // Write with "internal_use_full_qualified_name" = "true"
+      // Staging table with "internal_use_full_qualified_name" = "true"
       tmpDF.write
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(thisConnectorOptionsNoTable)
@@ -2000,6 +2000,32 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
         .option("dbtable", test_table_write)
         .mode(SaveMode.Overwrite)
         .save()
+      jdbcUpdate(s"drop table if exists $test_table_write")
+
+      // Without staging table with "internal_use_full_qualified_name" = "false"
+      assertThrows[Exception]({
+        tmpDF.write
+          .format(SNOWFLAKE_SOURCE_NAME)
+          .options(thisConnectorOptionsNoTable)
+          .option(Parameters.PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "false")
+          .option("dbtable", test_table_write)
+          .option("usestagingtable", "false")
+          .option("truncate_table", "true")
+          .mode(SaveMode.Overwrite)
+          .save()
+      })
+
+      // Without staging table with "internal_use_full_qualified_name" = "true"
+      tmpDF.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option(Parameters.PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "true")
+        .option("dbtable", test_table_write)
+        .option("usestagingtable", "false")
+        .option("truncate_table", "true")
+        .mode(SaveMode.Overwrite)
+        .save()
+      jdbcUpdate(s"drop table if exists $test_table_write")
     } finally {
       jdbcUpdate(s"drop table if exists $test_table_write")
       jdbcUpdate(s"drop table if exists public.$test_table_write")

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -2044,6 +2044,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
       jdbcUpdate(s"drop table if exists $test_table_timestamp")
       jdbcUpdate(s"drop table if exists $test_table_large_result")
       jdbcUpdate(s"drop table if exists $test_table_inf")
+      jdbcUpdate(s"drop table if exists $test_table_write")
       jdbcUpdate(s"drop table if exists public.$test_table_write")
       jdbcUpdate(s"drop table if exists $test_table_like")
     } finally {

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -1981,33 +1981,33 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
       // drop table in this schema
       jdbcUpdate(s"drop table if exists $test_table_write")
 
-      // Staging table with "internal_use_full_qualified_name" = "false"
+      // Staging table with "internal_use_fully_qualified_name" = "false"
       assertThrows[Exception]({
         tmpDF.write
           .format(SNOWFLAKE_SOURCE_NAME)
           .options(thisConnectorOptionsNoTable)
-          .option(Parameters.PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "false")
+          .option(Parameters.PARAM_INTERNAL_USE_FULLY_QUALIFIED_NAME, "false")
           .option("dbtable", test_table_write)
           .mode(SaveMode.Overwrite)
           .save()
       })
 
-      // Staging table with "internal_use_full_qualified_name" = "true"
+      // Staging table with "internal_use_fully_qualified_name" = "true"
       tmpDF.write
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(thisConnectorOptionsNoTable)
-        .option(Parameters.PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "true")
+        .option(Parameters.PARAM_INTERNAL_USE_FULLY_QUALIFIED_NAME, "true")
         .option("dbtable", test_table_write)
         .mode(SaveMode.Overwrite)
         .save()
       jdbcUpdate(s"drop table if exists $test_table_write")
 
-      // Without staging table with "internal_use_full_qualified_name" = "false"
+      // Without staging table with "internal_use_fully_qualified_name" = "false"
       assertThrows[Exception]({
         tmpDF.write
           .format(SNOWFLAKE_SOURCE_NAME)
           .options(thisConnectorOptionsNoTable)
-          .option(Parameters.PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "false")
+          .option(Parameters.PARAM_INTERNAL_USE_FULLY_QUALIFIED_NAME, "false")
           .option("dbtable", test_table_write)
           .option("usestagingtable", "false")
           .option("truncate_table", "true")
@@ -2015,11 +2015,11 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
           .save()
       })
 
-      // Without staging table with "internal_use_full_qualified_name" = "true"
+      // Without staging table with "internal_use_fully_qualified_name" = "true"
       tmpDF.write
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(thisConnectorOptionsNoTable)
-        .option(Parameters.PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "true")
+        .option(Parameters.PARAM_INTERNAL_USE_FULLY_QUALIFIED_NAME, "true")
         .option("dbtable", test_table_write)
         .option("usestagingtable", "false")
         .option("truncate_table", "true")

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -153,11 +153,11 @@ object Parameters {
   val PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME: String = knownParam(
     "internal_quote_json_field_name"
   )
-  // Internal option to use full qualified table name
+  // Internal option to use fully qualified table name
   // when detecting the table existence.
   // This option may be removed without any notice in any time.
-  val PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME: String = knownParam(
-    "internal_use_full_qualified_name"
+  val PARAM_INTERNAL_USE_FULLY_QUALIFIED_NAME: String = knownParam(
+    "internal_use_fully_qualified_name"
   )
 
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
@@ -615,8 +615,8 @@ object Parameters {
     def quoteJsonFieldName: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME, "true"))
     }
-    def useFullQualifiedName: Boolean = {
-      isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "true"))
+    def useFullyQualifiedName: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_FULLY_QUALIFIED_NAME, "true"))
     }
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -153,6 +153,12 @@ object Parameters {
   val PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME: String = knownParam(
     "internal_quote_json_field_name"
   )
+  // Internal option to use full qualified table name
+  // when detecting the table existence.
+  // This option may be removed without any notice in any time.
+  val PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME: String = knownParam(
+    "internal_use_full_qualified_name"
+  )
 
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
@@ -608,6 +614,9 @@ object Parameters {
     }
     def quoteJsonFieldName: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME, "true"))
+    }
+    def useFullQualifiedName: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_FULL_QUALIFIED_NAME, "true"))
     }
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -713,47 +713,49 @@ object Utils {
     }
   }
 
-  private[snowflake] def splitNameAs2Parts(objectName: String): (String, String) = {
+  private[snowflake] def splitNameAs2Parts(objectName: String): (Option[String], String) = {
     if (objectName.endsWith("\"")) {
       val nameStartIndex = objectName.dropRight(1).lastIndexOf(".\"")
       if (nameStartIndex > 0) {
-        (objectName.substring(0, nameStartIndex), objectName.substring(nameStartIndex + 1))
+        (Option(objectName.substring(0, nameStartIndex)),
+          objectName.substring(nameStartIndex + 1))
       } else if (objectName.startsWith("\"")) {
-        ("", objectName)
+        (None, objectName)
       } else {
         throw new Exception(s"Meet invalidate objectName: '$objectName'")
       }
     } else {
       if (objectName.indexOf(".") > -1) {
-        (objectName.substring(0, objectName.lastIndexOf(".")),
+        (Option(objectName.substring(0, objectName.lastIndexOf("."))),
           objectName.substring(objectName.lastIndexOf(".") + 1))
       } else {
-        ("", objectName)
+        (None, objectName)
       }
     }
   }
 
-  private[snowflake] def getFullQualifiedName(originalName: String, params: MergedParameters): String = {
+  private[snowflake] def getFullyQualifiedName(originalName: String, params: MergedParameters): String = {
     val trimmedName = originalName.trim
-    val (databaseSchemaName, tableName) = splitNameAs2Parts(trimmedName)
+    val (databaseSchemaOption, tableName) = splitNameAs2Parts(trimmedName)
     val currentDatabase = Utils.ensureQuoted(params.sfDatabase)
     val currentSchema = Utils.ensureQuoted(params.sfSchema)
-    if (databaseSchemaName.isEmpty) {
+    if (databaseSchemaOption.isEmpty) {
       // The originalName format is <tableName>
       s"$currentDatabase.$currentSchema.$tableName"
     } else {
+      val databaseSchemaName = databaseSchemaOption.get
       if (databaseSchemaName.endsWith(".")) {
         // The originalName format is <database>..<tableName>
         val databaseName = databaseSchemaName.dropRight(1)
         s"$databaseName.$currentSchema.$tableName"
       } else {
-        val (databaseName, schemaName) = splitNameAs2Parts(databaseSchemaName)
-        if (databaseName.isEmpty) {
+        val (databaseNameOption, schemaName) = splitNameAs2Parts(databaseSchemaName)
+        if (databaseNameOption.isEmpty) {
           // The originalName format is <schema>.<tableName>
           s"$currentDatabase.$schemaName.$tableName"
         } else {
           // The originalName format is <database>.<schema>.<tableName>
-          s"$databaseName.$schemaName.$tableName"
+          s"${databaseNameOption.get}.$schemaName.$tableName"
         }
       }
     }

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -362,9 +362,14 @@ private[io] object StageWriter {
       }
 
     try {
+      val tableName = if (params.useFullQualifiedName) {
+        Utils.getFullQualifiedName(table.toString, params)
+      } else {
+        table.toString
+      }
       // purge tables when overwriting
       if (saveMode == SaveMode.Overwrite &&
-          DefaultJDBCWrapper.tableExists(conn, table.toString)) {
+          DefaultJDBCWrapper.tableExists(conn, tableName)) {
         if (params.useStagingTable) {
           if (params.truncateTable) {
             conn.createTableLike(tempTable.name, table.name)
@@ -377,7 +382,7 @@ private[io] object StageWriter {
       // CREATE TABLE IF NOT EXIST command. This command doesn't actually
       // create a table but it needs CREATE TABLE privilege.
       if (saveMode == SaveMode.Overwrite ||
-        !DefaultJDBCWrapper.tableExists(conn, table.toString))
+        !DefaultJDBCWrapper.tableExists(conn, tableName))
       {
         conn.createTable(targetTable.name, schema, params,
           overwrite = false, temporary = false)

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -281,21 +281,21 @@ private[io] object StageWriter {
     val writeTableState = new WriteTableState(conn)
 
     try {
-      val fullTableName = if (params.useFullQualifiedName) {
-        Utils.getFullQualifiedName(tableName, params)
+      val fullyQualifiedName = if (params.useFullyQualifiedName) {
+        Utils.getFullyQualifiedName(tableName, params)
       } else {
         tableName
       }
       // Drop table only if necessary.
       if (saveMode == SaveMode.Overwrite &&
-        DefaultJDBCWrapper.tableExists(conn, fullTableName) &&
+        DefaultJDBCWrapper.tableExists(conn, fullyQualifiedName) &&
         !params.truncateTable )
       {
         writeTableState.dropTable(tableName)
       }
 
       // If create table if table doesn't exist
-      if (!DefaultJDBCWrapper.tableExists(conn, fullTableName))
+      if (!DefaultJDBCWrapper.tableExists(conn, fullyQualifiedName))
       {
         writeTableState.createTable(tableName, schema, params)
       } else if (params.truncateTable && saveMode == SaveMode.Overwrite) {
@@ -367,14 +367,14 @@ private[io] object StageWriter {
       }
 
     try {
-      val fullTableName = if (params.useFullQualifiedName) {
-        Utils.getFullQualifiedName(table.toString, params)
+      val fullyQualifiedName = if (params.useFullyQualifiedName) {
+        Utils.getFullyQualifiedName(table.toString, params)
       } else {
         table.toString
       }
       // purge tables when overwriting
       if (saveMode == SaveMode.Overwrite &&
-          DefaultJDBCWrapper.tableExists(conn, fullTableName)) {
+          DefaultJDBCWrapper.tableExists(conn, fullyQualifiedName)) {
         if (params.useStagingTable) {
           if (params.truncateTable) {
             conn.createTableLike(tempTable.name, table.name)
@@ -387,7 +387,7 @@ private[io] object StageWriter {
       // CREATE TABLE IF NOT EXIST command. This command doesn't actually
       // create a table but it needs CREATE TABLE privilege.
       if (saveMode == SaveMode.Overwrite ||
-        !DefaultJDBCWrapper.tableExists(conn, fullTableName))
+        !DefaultJDBCWrapper.tableExists(conn, fullyQualifiedName))
       {
         conn.createTable(targetTable.name, schema, params,
           overwrite = false, temporary = false)
@@ -422,7 +422,7 @@ private[io] object StageWriter {
       )
 
       if (saveMode == SaveMode.Overwrite && params.useStagingTable) {
-        if (DefaultJDBCWrapper.tableExists(conn, fullTableName)) {
+        if (DefaultJDBCWrapper.tableExists(conn, fullyQualifiedName)) {
           conn.swapTable(table.name, tempTable.name)
           conn.dropTable(tempTable.name)
         } else {

--- a/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
@@ -128,11 +128,11 @@ class UtilsSuite extends FunSuite with Matchers {
     assert(Utils.getLastGetCommand == null)
   }
 
-  test("Utils.getFullQualifiedName()") {
+  test("Utils.getFullyQualifiedName()") {
     case class TestItem(sfDatabase: String,
                         sfSchema: String,
                         tableName: String,
-                        fullQualifiedName: String)
+                        fullyQualifiedName: String)
     val TestItems = Seq(
       // un-quoted database & schema, un-quoted table name
       TestItem("test_db", "test_schema", "table1", s""""TEST_DB"."TEST_SCHEMA".table1"""),
@@ -163,32 +163,32 @@ class UtilsSuite extends FunSuite with Matchers {
         Parameters.PARAM_SF_SCHEMA -> item.sfSchema
       )
       val param = Parameters.MergedParameters(sfOptions)
-      // println(s"${item.sfDatabase}, ${item.sfSchema}, ${item.tableName} -> ${item.fullQualifiedName}")
-      // println(Utils.getFullQualifiedName(item.tableName, param))
-      assert(Utils.getFullQualifiedName(item.tableName, param)
-        .equals(item.fullQualifiedName))
+      // println(s"${item.sfDatabase}, ${item.sfSchema}, ${item.tableName} -> ${item.fullyQualifiedName}")
+      // println(Utils.getFullyQualifiedName(item.tableName, param))
+      assert(Utils.getFullyQualifiedName(item.tableName, param)
+        .equals(item.fullyQualifiedName))
     })
   }
 
   test("Utils.splitNameAs2Parts") {
-    var v1 = ("", "")
+    var v1 = (Option(""), "")
     v1 = Utils.splitNameAs2Parts("name1")
     assert(v1._1.isEmpty && v1._2.equals("name1"))
     v1 = Utils.splitNameAs2Parts("schema1.name1")
-    assert(v1._1.equals("schema1") && v1._2.equals("name1"))
+    assert(v1._1.get.equals("schema1") && v1._2.equals("name1"))
     v1 = Utils.splitNameAs2Parts("\"schema1\".name1")
-    assert(v1._1.equals("\"schema1\"") && v1._2.equals("name1"))
+    assert(v1._1.get.equals("\"schema1\"") && v1._2.equals("name1"))
     v1 = Utils.splitNameAs2Parts("database1.schema1.name1")
-    assert(v1._1.equals("database1.schema1") && v1._2.equals("name1"))
+    assert(v1._1.get.equals("database1.schema1") && v1._2.equals("name1"))
 
     v1 = Utils.splitNameAs2Parts("\"name1\"")
     assert(v1._1.isEmpty && v1._2.equals("\"name1\""))
     v1 = Utils.splitNameAs2Parts("schema1.\"name1\"")
-    assert(v1._1.equals("schema1") && v1._2.equals("\"name1\""))
+    assert(v1._1.get.equals("schema1") && v1._2.equals("\"name1\""))
     v1 = Utils.splitNameAs2Parts("\"schema1\".\"name1\"")
-    assert(v1._1.equals("\"schema1\"") && v1._2.equals("\"name1\""))
+    assert(v1._1.get.equals("\"schema1\"") && v1._2.equals("\"name1\""))
     v1 = Utils.splitNameAs2Parts("\"database1\".\"schema1\".\"name1\"")
-    assert(v1._1.equals("\"database1\".\"schema1\"") && v1._2.equals("\"name1\""))
+    assert(v1._1.get.equals("\"database1\".\"schema1\"") && v1._2.equals("\"name1\""))
 
     // negative test
     assertThrows[Exception](Utils.splitNameAs2Parts("name1\""))


### PR DESCRIPTION
Issue description
============
When writing to a table, SC detects the target table existence with `desc table <tableName>`. Suppose the table name is `t1` and `sfschema` is set as `schema1`, if there is no `schema1.t1` table but `public.t1` exists, the `desc table t1` will return the table of `public.t1`. This is described in snowflake document: https://docs.snowflake.com/en/sql-reference/name-resolution.html#resolution-when-schema-omitted-double-dot-notation . But it is not SC's expectation.

Fix proposal
=========
SC uses the full qualified table name to detect the table existence. This needs to be handled very carefully. Make sure below cases are considered:
1. table name may be quoted or not.
2. table name may include special characters.
3. table name may includes schema name only, database name only or both database and schema name.
4. sfSchema and sfDatabase may include special characters or be quoted.

Implementation
============
1. Introduce an internal option `internal_use_full_qualified_name` to disable the fix if necessary.
2. Implement a private function `Utils.splitNameAs2Parts(name)` to split table name from the full name. For example, it splits `database1.schema1.table1` as (`database1.schema1`, `table1`); it splits `"database1"."schema1"` as (`"database1"`, `"schema1"`).
3. Implement a private function `Utils.getFullQualifiedName(name, params)` to get the full qualified name. If database name or schema name are not included in the original name, use sfdatabase or sfschema. For example,
- sfdatabase=test_db, sfschema=test_schema, table name is table1, the full name is `"TEST_DB"."TEST_SCHEMA".table1`.
- sfdatabase=test_db, sfschema=test_schema, table name is schema1.table1, the full name is `"TEST_DB".schema1.table1`.
For more cases, refer to test of `Utils.getFullQualifiedName()` in `UtilsSuite.scala`
4. If `internal_use_full_qualified_name` is true, use the full qualified name when detecting table existence in `StageWriter`