### PR TITLE
SNOW-262080 check table existence in current schema only

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -2050,6 +2050,92 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
     }
   }
 
+  test("The fix of SNOW-262080 with SaveMode.ErrorIfExists") {
+    setupLargeResultTable
+    val tmpDF = sparkSession
+      .sql("select * from test_table_large_result where int_c < 10")
+
+    try {
+      // create one same name table in schema:public
+      jdbcUpdate(s"create table public.$test_table_write(c1 int)")
+      // drop table in this schema
+      jdbcUpdate(s"drop table if exists $test_table_write")
+
+      // Staging table with check_table_existence_in_current_schema = "false"
+      assertThrows[Exception]({
+        // Reproduce issue. The table doesn't exists, but table existence checking returns true.
+        tmpDF.write
+          .format(SNOWFLAKE_SOURCE_NAME)
+          .options(thisConnectorOptionsNoTable)
+          .option(Parameters.PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY, "false")
+          .option("dbtable", test_table_write)
+          .mode(SaveMode.ErrorIfExists)
+          .save()
+      })
+
+      // Staging table with check_table_existence_in_current_schema = "true"
+      tmpDF.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option(Parameters.PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY, "true")
+        .option("dbtable", test_table_write)
+        .mode(SaveMode.ErrorIfExists)
+        .save()
+    } finally {
+      jdbcUpdate(s"drop table if exists $test_table_write")
+      jdbcUpdate(s"drop table if exists public.$test_table_write")
+    }
+  }
+
+  test("The fix of SNOW-262080 with SaveMode.Ignore") {
+    setupLargeResultTable
+    val tmpDF = sparkSession
+      .sql("select * from test_table_large_result where int_c < 10")
+
+    try {
+      // create one same name table in schema:public
+      jdbcUpdate(s"create table public.$test_table_write(c1 int)")
+      // drop table in this schema
+      jdbcUpdate(s"drop table if exists $test_table_write")
+
+      // Staging table with check_table_existence_in_current_schema = "false"
+      // Reproduce issue:
+      // The table doesn't exist, but table existence checking returns true.
+      // So the write is ignored. Later read fails.
+      tmpDF.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option(Parameters.PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY, "false")
+        .option("dbtable", test_table_write)
+        .mode(SaveMode.Ignore)
+        .save()
+      assertThrows[Exception]({
+        sparkSession.read
+          .format(SNOWFLAKE_SOURCE_NAME)
+          .options(thisConnectorOptionsNoTable)
+          .option("dbtable", s"${params.sfDatabase}.${params.sfSchema}.$test_table_write")
+          .load()
+      })
+
+      // Staging table with check_table_existence_in_current_schema = "true"
+      tmpDF.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option(Parameters.PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY, "true")
+        .option("dbtable", test_table_write)
+        .mode(SaveMode.Ignore)
+        .save()
+      sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", s"${params.sfDatabase}.${params.sfSchema}.$test_table_write")
+        .load()
+    } finally {
+      jdbcUpdate(s"drop table if exists $test_table_write")
+      jdbcUpdate(s"drop table if exists public.$test_table_write")
+    }
+  }
+
   override def beforeEach(): Unit = {
     super.beforeEach()
   }

--- a/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
@@ -111,7 +111,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
 
     def tableExists: Boolean =
       if (params.checkTableExistenceInCurrentSchemaOnly) {
-        DefaultJDBCWrapper.tableExistsInCurrentSchema(params, table.toString)
+        jdbcWrapper.tableExistsInCurrentSchema(params, table.toString)
       } else {
         val conn = jdbcWrapper.getConnector(params)
         try {

--- a/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
@@ -109,14 +109,17 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
       )
     }
 
-    def tableExists: Boolean = {
-      val conn = jdbcWrapper.getConnector(params)
-      try {
-        jdbcWrapper.tableExists(conn, table.toString)
-      } finally {
-        conn.close()
+    def tableExists: Boolean =
+      if (params.checkTableExistenceInCurrentSchemaOnly) {
+        DefaultJDBCWrapper.tableExistsInCurrentSchema(params, table.toString)
+      } else {
+        val conn = jdbcWrapper.getConnector(params)
+        try {
+          jdbcWrapper.tableExists(conn, table.toString)
+        } finally {
+          conn.close()
+        }
       }
-    }
 
     val (doSave, dropExisting) = saveMode match {
       case SaveMode.Append => (true, false)

--- a/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
@@ -109,17 +109,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
       )
     }
 
-    def tableExists: Boolean =
-      if (params.checkTableExistenceInCurrentSchemaOnly) {
-        jdbcWrapper.tableExistsInCurrentSchema(params, table.toString)
-      } else {
-        val conn = jdbcWrapper.getConnector(params)
-        try {
-          jdbcWrapper.tableExists(conn, table.toString)
-        } finally {
-          conn.close()
-        }
-      }
+    def tableExists: Boolean = jdbcWrapper.tableExists(params, table.toString)
 
     val (doSave, dropExisting) = saveMode match {
       case SaveMode.Append => (true, false)

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -153,6 +153,15 @@ object Parameters {
   val PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME: String = knownParam(
     "internal_quote_json_field_name"
   )
+  // Internal option to check table existence in current schema only.
+  // By default, if customer specifies an unqualified table name
+  // (without schema or database name), snowflake checks table existence
+  // through a search path. For example, it checks current schema and PUBLIC
+  // schema.
+  // This option may be removed without any notice in any time.
+  val PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY: String = knownParam(
+    "internal_check_table_existence_in_current_schema_only"
+  )
 
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
@@ -608,6 +617,9 @@ object Parameters {
     }
     def quoteJsonFieldName: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME, "true"))
+    }
+    def checkTableExistenceInCurrentSchemaOnly: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY, "true"))
     }
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -156,8 +156,8 @@ object Parameters {
   // Internal option to check table existence in current schema only.
   // By default, if customer specifies an unqualified table name
   // (without schema or database name), snowflake checks table existence
-  // through a search path. For example, it checks current schema and PUBLIC
-  // schema.
+  // through a search path. For example, it checks whether it exists
+  // in current schema first; if not, it will check PUBLIC schema.
   // This option may be removed without any notice in any time.
   val PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY: String = knownParam(
     "internal_check_table_existence_in_current_schema_only"

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -288,23 +288,26 @@ private[snowflake] class JDBCWrapper {
   /**
     * Returns true if the table already exists in the JDBC database.
     * By default, if table is an unqualified table name (without schema or database name),
-    * snowflake checks table existence through a search path. For example,
+    * snowflake checks table existence through the default search path. For example,
     * it checks current schema and PUBLIC schema. If the caller intends to check
     * the table existence in current schema only. The caller needs to alter session to set
     * search_path as $current explicitly, for example,
     * conn.createStatement().execute("alter session set search_path='$current'")
-    * or use alternative function: tableExistsInCurrentSchema().
     */
   def tableExists(conn: Connection, table: String): Boolean =
     conn.tableExists(table)
 
   /**
-    * Returns true if the table already exists in the current schema.
+    * Check the table existence in the current schema only if the option of
+    * 'internal_check_table_existence_in_current_schema_only' is true.
+    * Otherwise, checks table existence through the default search path.
     */
-  private[snowflake] def tableExistsInCurrentSchema(params: MergedParameters, table: String): Boolean = {
+  private[snowflake] def tableExists(params: MergedParameters, table: String): Boolean = {
     val conn = getConnector(params)
     try {
-      conn.createStatement().execute("alter session set search_path='$current'")
+      if (params.checkTableExistenceInCurrentSchemaOnly){
+        conn.createStatement().execute("alter session set search_path='$current'")
+      }
       conn.tableExists(table)
     } finally {
       conn.close()

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -281,16 +281,19 @@ private[io] object StageWriter {
     val writeTableState = new WriteTableState(conn)
 
     try {
+      val tableExists = if (params.checkTableExistenceInCurrentSchemaOnly){
+        DefaultJDBCWrapper.tableExistsInCurrentSchema(params, tableName)
+      } else {
+        DefaultJDBCWrapper.tableExists(conn, tableName)
+      }
       // Drop table only if necessary.
-      if (saveMode == SaveMode.Overwrite &&
-        DefaultJDBCWrapper.tableExists(conn, tableName) &&
-        !params.truncateTable )
+      if (saveMode == SaveMode.Overwrite && tableExists && !params.truncateTable)
       {
         writeTableState.dropTable(tableName)
       }
 
       // If create table if table doesn't exist
-      if (!DefaultJDBCWrapper.tableExists(conn, tableName))
+      if (!tableExists)
       {
         writeTableState.createTable(tableName, schema, params)
       } else if (params.truncateTable && saveMode == SaveMode.Overwrite) {
@@ -362,9 +365,13 @@ private[io] object StageWriter {
       }
 
     try {
+      val tableExists = if (params.checkTableExistenceInCurrentSchemaOnly){
+        DefaultJDBCWrapper.tableExistsInCurrentSchema(params, table.toString)
+      } else {
+        DefaultJDBCWrapper.tableExists(conn, table.toString)
+      }
       // purge tables when overwriting
-      if (saveMode == SaveMode.Overwrite &&
-          DefaultJDBCWrapper.tableExists(conn, table.toString)) {
+      if (saveMode == SaveMode.Overwrite && tableExists) {
         if (params.useStagingTable) {
           if (params.truncateTable) {
             conn.createTableLike(tempTable.name, table.name)
@@ -376,8 +383,7 @@ private[io] object StageWriter {
       // If the SaveMode is 'Append' and the target exists, skip
       // CREATE TABLE IF NOT EXIST command. This command doesn't actually
       // create a table but it needs CREATE TABLE privilege.
-      if (saveMode == SaveMode.Overwrite ||
-        !DefaultJDBCWrapper.tableExists(conn, table.toString))
+      if (saveMode == SaveMode.Overwrite || !tableExists)
       {
         conn.createTable(targetTable.name, schema, params,
           overwrite = false, temporary = false)
@@ -412,7 +418,7 @@ private[io] object StageWriter {
       )
 
       if (saveMode == SaveMode.Overwrite && params.useStagingTable) {
-        if (conn.tableExists(table.toString)) {
+        if (tableExists) {
           conn.swapTable(table.name, tempTable.name)
           conn.dropTable(tempTable.name)
         } else {

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -281,11 +281,7 @@ private[io] object StageWriter {
     val writeTableState = new WriteTableState(conn)
 
     try {
-      val tableExists = if (params.checkTableExistenceInCurrentSchemaOnly){
-        DefaultJDBCWrapper.tableExistsInCurrentSchema(params, tableName)
-      } else {
-        DefaultJDBCWrapper.tableExists(conn, tableName)
-      }
+      val tableExists = DefaultJDBCWrapper.tableExists(params, tableName)
       // Drop table only if necessary.
       if (saveMode == SaveMode.Overwrite && tableExists && !params.truncateTable)
       {
@@ -365,11 +361,7 @@ private[io] object StageWriter {
       }
 
     try {
-      val tableExists = if (params.checkTableExistenceInCurrentSchemaOnly){
-        DefaultJDBCWrapper.tableExistsInCurrentSchema(params, table.toString)
-      } else {
-        DefaultJDBCWrapper.tableExists(conn, table.toString)
-      }
+      val tableExists = DefaultJDBCWrapper.tableExists(params, table.toString)
       // purge tables when overwriting
       if (saveMode == SaveMode.Overwrite && tableExists) {
         if (params.useStagingTable) {


### PR DESCRIPTION
Issue description
============
When writing to a table, SC detects the target table existence with desc table <tableName>. Suppose the table name is t1 and sfschema is set as schema1, if there is no schema1.t1 table but public.t1 exists, the desc table t1 will return the table of public.t1. This is described in snowflake document: https://docs.snowflake.com/en/sql-reference/name-resolution.html#resolution-when-schema-omitted-double-dot-notation . But it is not SC's expectation.

Fix proposal
=========
When writing to a snowflake table, SC checks the table existence in current schema only. To play it safe, a new JDBC connection is created and set the search path as current schema only. For example, 
```
conn.createStatement().execute("alter session set search_path='$current'")
```
In addition, add a new internal option 'internal_check_table_existence_in_current_schema_only' to disable this behavior if necessary. Its default is true.