### PR TITLE
SNOW-262080 Remove redundant function JDBCDriver.tableExists(conn,table)

### DIFF
--- a/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/ClusterTestResult.scala
+++ b/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/ClusterTestResult.scala
@@ -45,7 +45,7 @@ class ClusterTestResult(builder: ClusterTestResultBuilder) {
 
     // Create test result table if it doesn't exist.
     if (!DefaultJDBCWrapper.tableExists(
-          connection,
+          TestUtils.param,
           TestUtils.CLUSTER_TEST_RESULT_TABLE
         )) {
       DefaultJDBCWrapper.executeInterruptibly(

--- a/src/it/scala/net/snowflake/spark/snowflake/DecimalIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/DecimalIntegrationSuite.scala
@@ -55,7 +55,7 @@ class DecimalIntegrationSuite extends IntegrationSuiteBase {
             .executeUpdate(s"INSERT INTO $tableName VALUES ($x)")
         }
         conn.commit()
-        assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+        assert(DefaultJDBCWrapper.tableExists(params, tableName))
         val loadedDf = sparkSession.read
           .format(SNOWFLAKE_SOURCE_NAME)
           .options(connectorOptions)

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -131,7 +131,7 @@ trait IntegrationSuiteBase
         .option("dbtable", tableName)
         .mode(saveMode)
         .save()
-      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      assert(DefaultJDBCWrapper.tableExists(params, tableName))
       val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptions)

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
@@ -41,7 +41,7 @@ class PushdownEnhancement01 extends IntegrationSuiteBase {
   private val test_table_in: String = s"test_table_in_$randomSuffix"
   private val test_table_in_set: String = s"test_table_in_set_$randomSuffix"
   private val test_table_cast: String = s"test_table_cast_$randomSuffix"
-  private val test_table_coalesce = "test_table_coalesce_$randomSuffix"
+  private val test_table_coalesce = s"test_table_coalesce_$randomSuffix"
 
   override def afterAll(): Unit = {
     try {

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeIntegrationSuite.scala
@@ -268,7 +268,7 @@ class SnowflakeIntegrationSuite extends IntegrationSuiteBase {
         .mode(SaveMode.ErrorIfExists)
         .save()
 
-      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      assert(DefaultJDBCWrapper.tableExists(params, tableName))
 
       val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
@@ -449,7 +449,7 @@ class SnowflakeIntegrationSuite extends IntegrationSuiteBase {
         .option("dbtable", tableName)
         .mode(SaveMode.ErrorIfExists)
         .save()
-      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      assert(DefaultJDBCWrapper.tableExists(params, tableName))
       val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptions)
@@ -511,7 +511,7 @@ class SnowflakeIntegrationSuite extends IntegrationSuiteBase {
         .option("dbtable", tableName)
         .mode(SaveMode.ErrorIfExists)
         .save()
-      assert(DefaultJDBCWrapper.tableExists(conn, s"PUBLIC.$tableName"))
+      assert(DefaultJDBCWrapper.tableExists(params, s"PUBLIC.$tableName"))
       // Try overwriting that table while using the schema-qualified table name:
       df.write
         .format(SNOWFLAKE_SOURCE_NAME)
@@ -551,7 +551,7 @@ class SnowflakeIntegrationSuite extends IntegrationSuiteBase {
         .option("dbtable", tableName)
         .mode(SaveMode.ErrorIfExists)
         .save()
-      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      assert(DefaultJDBCWrapper.tableExists(params, tableName))
 
       sparkSession
         .createDataFrame(
@@ -565,7 +565,7 @@ class SnowflakeIntegrationSuite extends IntegrationSuiteBase {
         .mode(SaveMode.Overwrite)
         .save()
 
-      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      assert(DefaultJDBCWrapper.tableExists(params, tableName))
       val loadedDf = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptions)

--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -244,7 +244,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
       println(s"""Test table: "$table"""")
       // Make sure table doesnt' exist
       jdbcUpdate(s"drop table if exists $table")
-      assert(!DefaultJDBCWrapper.tableExists(conn, table.toString))
+      assert(!DefaultJDBCWrapper.tableExists(params, table.toString))
 
       // Old table doesn't exist so DROP table and TRUNCATE table never happen
       val testConditions = Array(
@@ -274,7 +274,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
         }
 
         // The original table should not exist
-        assert(!DefaultJDBCWrapper.tableExists(conn, table.toString))
+        assert(!DefaultJDBCWrapper.tableExists(params, table.toString))
       })
 
       // Disable test hook in the end

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -286,21 +286,12 @@ private[snowflake] class JDBCWrapper {
     }
 
   /**
-    * Returns true if the table already exists in the JDBC database.
-    * By default, if table is an unqualified table name (without schema or database name),
-    * snowflake checks table existence through the default search path. For example,
-    * it checks current schema and PUBLIC schema. If the caller intends to check
-    * the table existence in current schema only. The caller needs to alter session to set
-    * search_path as $current explicitly, for example,
-    * conn.createStatement().execute("alter session set search_path='$current'")
-    */
-  def tableExists(conn: Connection, table: String): Boolean =
-    conn.tableExists(table)
-
-  /**
-    * Check the table existence in the current schema only if the option of
-    * 'internal_check_table_existence_in_current_schema_only' is true.
-    * Otherwise, checks table existence through the default search path.
+    * Returns true if the table already exists.
+    * By default, it checks the table existence in current schema only because
+    * the default value for 'internal_check_table_existence_in_current_schema_only' is true.
+    * If the caller intends to check the table existence through the snowflake default
+    * search path, the caller needs to set 'internal_check_table_existence_in_current_schema_only'
+    * as false explicitly.
     */
   private[snowflake] def tableExists(params: MergedParameters, table: String): Boolean = {
     val conn = getConnector(params)

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -44,7 +44,7 @@ class MiscSuite01 extends FunSuite with Matchers {
       Parameters.PARAM_PROXY_PORT -> "1234",
       Parameters.PARAM_PROXY_USER -> "proxyUser",
       Parameters.PARAM_PROXY_PASSWORD -> "proxyPassword",
-      Parameters.PARAM_NON_PROXY_HOSTS -> "nonProxyHosts",
+      Parameters.PARAM_NON_PROXY_HOSTS -> "nonProxyHosts"
     )
     val param = Parameters.MergedParameters(sfOptions)
     val proxyInfo = param.proxyInfo.get

--- a/src/test/scala/net/snowflake/spark/snowflake/MockSF.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MockSF.scala
@@ -112,7 +112,7 @@ class MockSF(params: Map[String, String],
     override def answer(invocation: InvocationOnMock): Boolean = {
       existingTablesAndSchemas.contains(invocation.getArguments()(1).asInstanceOf[String])
     }
-  }).when(jdbcWrapper).tableExists(any[Connection], anyString())
+  }).when(jdbcWrapper).tableExists(any[MergedParameters], anyString())
 
   doAnswer(new Answer[StructType] {
     override def answer(invocation: InvocationOnMock): StructType = {


### PR DESCRIPTION
This is a follow-up PR for https://github.com/snowflakedb/spark-snowflake/pull/328. PR 328 introduced below new function. So `def tableExists(conn: Connection, table: String)` is not necessary any more. But the old function is used in test code. To avoid the PR to have too much change, we introduce this follow-up PR to remove the old function.
The function is not `private[snowflake]`, but the class `JDBCWrapper` is `private[snowflake]`, so it is safe to remove this function.

```
  private[snowflake] def tableExists(params: MergedParameters, table: String): Boolean = {
    val conn = getConnector(params)
    try {
      if (params.checkTableExistenceInCurrentSchemaOnly){
        conn.createStatement().execute("alter session set search_path='$current'")
      }
      conn.tableExists(table)
    } finally {
      conn.close()
    }
  }
```