### PR TITLE
SNOW-293194 Quote column names when writing with JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The main version of `spark-snowflake` works with Spark 2.4. For use with Spark 2.3 and 2.2, please use tag `vx.x.x-spark_2.3` and `vx.x.x-spark_2.2`. 
 
-To use it, provide the dependency for Spark in the form of `net.snowflake:spark-snowflake_$SCALA_VERSION:$RELEASE`, e.g. `net.snowflake:spark-snowflake_2.11:2.2.2`. See [Spark Packages](https://spark-packages.org/package/snowflakedb/spark-snowflake) and [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cspark-snowflake) for more info.
+To use it, provide the dependency for Spark in the form of `net.snowflake:spark-snowflake_$SCALA_VERSION:$RELEASE`, e.g. `net.snowflake:spark-snowflake_2.11:2.2.2`. See [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cspark-snowflake) for more info.
 
 For a version working with Spark 1.5 and 1.6, please use `branch-1.x`. Artifacts of that version are also available in the Snowflake UI.
 

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -1882,37 +1882,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
   }
 
   test("write with JSON and without special characters in field name") {
-    val partitionCount = 1
-    val rowCountPerPartition = 2
-    // Create RDD which generates data with multiple partitions
-    val testRDD: RDD[Row] = sparkSession.sparkContext
-      .parallelize(Seq[Int](), partitionCount)
-      .mapPartitions { _ => {
-        (1 to rowCountPerPartition).map { i => {
-          Row(s"name_$i",
-            Map("a1" -> s"value_a$i", "a2" -> s"value_aa$i"),
-            Map("b1" -> s"value_b$i", "b2" -> s"value_bb$i"),
-            Map("c1" -> s"value_c$i", "c2" -> s"value_cc$i"),
-            Map("d1" -> s"value_d$i", "d2" -> s"value_dd$i"))
-        }
-        }.iterator
-      }
-      }
-
-    // Field names have special characters
-    val (colName0, colName1, colName2, colName3, colName4)
-    : (String, String, String, String, String) =
-      ("FIRST_name", "some_for1", "some_for2", "some_for3", "some_for4")
-    val schema = StructType(List(
-      StructField(colName0, StringType),
-      StructField(colName1, MapType(StringType, StringType)),
-      StructField(colName2, MapType(StringType, StringType)),
-      StructField(colName3, MapType(StringType, StringType)),
-      StructField(colName4, MapType(StringType, StringType))
-    ))
-
-    // Convert RDD to DataFrame
-    val df = sparkSession.createDataFrame(testRDD, schema)
+    val df = getTestJsonDF("FIRST_name", "some_for1", "some_for2", "some_for3", "some_for4")
 
     val quotesFieldName = Seq("true", "false")
     // If there is no special characters in field names,
@@ -1967,6 +1937,69 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
         expectedResult, bypass = true
       )
     })
+  }
+
+  private def getTestJsonDF(colName0: String,
+                            colName1: String,
+                            colName2: String,
+                            colName3: String,
+                            colName4: String): DataFrame = {
+    val partitionCount = 1
+    val rowCountPerPartition = 1
+    val testRDD: RDD[Row] = sparkSession.sparkContext
+      .parallelize(Seq[Int](), partitionCount)
+      .mapPartitions { _ => {
+        (1 to rowCountPerPartition).map { i => {
+          Row(s"name_$i",
+            Map("a1" -> s"value_a$i", "a2" -> s"value_aa$i"),
+            Map("b1" -> s"value_b$i", "b2" -> s"value_bb$i"),
+            Map("c1" -> s"value_c$i", "c2" -> s"value_cc$i"),
+            Map("d1" -> s"value_d$i", "d2" -> s"value_dd$i")
+          )
+        }
+        }.iterator
+      }
+      }
+
+    val schema = StructType(List(
+      StructField(colName0, StringType),
+      StructField(colName1, MapType(StringType, StringType)),
+      StructField(colName2, MapType(StringType, StringType)),
+      StructField(colName3, MapType(StringType, StringType)),
+      StructField(colName4, MapType(StringType, StringType))
+    ))
+
+    sparkSession.createDataFrame(testRDD, schema)
+  }
+
+  test("column name is snowflake keyword: SNOW-293194") {
+    val df = getTestJsonDF("create", "table", "View", "INSERT", "test")
+    df.write
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_write)
+      .mode(SaveMode.Overwrite)
+      .save()
+
+    // It fails if disable the column name quotation
+    assertThrows[Exception] {
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("dbtable", test_table_write)
+        .option(Parameters.PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME, "false")
+        .mode(SaveMode.Overwrite)
+        .save()
+    }
+
+    // If the column name is not key word, disable it also work
+    val df2 = getTestJsonDF("create1", "table1", "View1", "INSERT1", "test1")
+    df2.write
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option(Parameters.PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME, "false")
+      .mode(SaveMode.Overwrite)
+      .save()
   }
 
   test("repro & test SNOW-262080") {

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -147,8 +147,8 @@ object Parameters {
   val PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY: String = knownParam(
     "internal_staging_table_name_remove_quotes_only"
   )
-  // Internal option to quote the JSON field names when writing
-  // DataFrame to a snowflake table with JSON format.
+  // Internal option to quote the JSON field names and column names
+  // when writing DataFrame to a snowflake table with JSON format.
   // This option may be removed without any notice in any time.
   val PARAM_INTERNAL_QUOTE_JSON_FIELD_NAME: String = knownParam(
     "internal_quote_json_field_name"

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -697,7 +697,18 @@ private[io] object StageWriter {
             DefaultJDBCWrapper.resolveTable(conn, table.name, params)
           if (list.isEmpty || list.get.isEmpty) {
             ConstantString("(") + tableSchema.fields
-              .map(_.name)
+              .map(
+                x =>
+                  if (params.quoteJsonFieldName) {
+                    if (params.keepOriginalColumnNameCase) {
+                      Utils.quotedNameIgnoreCase(x.name)
+                    } else {
+                      Utils.ensureQuoted(x.name)
+                    }
+                  } else {
+                    x.name
+                  }
+              )
               .mkString(",") + ")"
           } else {
             ConstantString("(") +


### PR DESCRIPTION
Issue description
============
When writing a dataframe with Json format, spark connector specified the column names in the COPY command. For example, 
```
copy into test_table_write_749083442521451968_staging_1100817666 (
  CREATE,TABLE,VIEW,INSERT,TEST )
from ( SELECT_FROM_STAGE ) 
FILE_FORMAT = (TYPE = JSON )
```
But, in this customer case, they are using snowflake key word as column name like CREATE. syntax error happens for COPY command.

Fix
======
The fix is straight forward.  We need to quote the column name in the COPY commnand. For example,
```
copy into test_table_write_749083442521451968_staging_617019349 (
 "CREATE","TABLE","VIEW","INSERT","TEST" )
from ( SELECT_FROM_STAGE ) 
FILE_FORMAT = ( TYPE = JSON)
```
