### PR TITLE
SNOW-358401 Support spark 3.1

### DIFF
--- a/.github/docker/build_image.sh
+++ b/.github/docker/build_image.sh
@@ -33,8 +33,8 @@ cd ../..
 
 # Build docker image
 docker build \
---build-arg SPARK_URL=https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz \
---build-arg SPARK_BINARY_NAME=spark-3.0.0-bin-hadoop2.7.tgz \
+--build-arg SPARK_URL=https://archive.apache.org/dist/spark/spark-3.1.1/spark-3.1.1-bin-hadoop2.7.tgz \
+--build-arg SPARK_BINARY_NAME=spark-3.1.1-bin-hadoop2.7.tgz \
 --build-arg JDBC_URL=https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/${TEST_JDBC_VERSION}/$JDBC_JAR_NAME \
 --build-arg JDBC_BINARY_NAME=$JDBC_JAR_NAME \
 --build-arg SPARK_CONNECTOR_LOCATION=target/scala-${TEST_SCALA_VERSION}/$SPARK_CONNECTOR_JAR_NAME \

--- a/.github/workflows/ClusterTest.yml
+++ b/.github/workflows/ClusterTest.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         scala_version: [ '2.12.11' ]
-        spark_version: [ '3.0.0' ]
+        spark_version: [ '3.1.1' ]
         use_copy_unload: [ 'true' ]
         cloud_provider: [ 'gcp' ]
     env:
         SNOWFLAKE_TEST_CONFIG_SECRET: ${{ secrets.SNOWFLAKE_TEST_CONFIG_SECRET }}
-        TEST_SPARK_VERSION: '3.0'
+        TEST_SPARK_VERSION: '3.1'
         DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.0.0'
         TEST_SCALA_VERSION: '2.12'
         TEST_COMPILE_SCALA_VERSION: '2.12.11'

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.12.11' ]
-       spark_version: [ '3.0.0' ]
+       spark_version: [ '3.1.1' ]
        use_copy_unload: [ 'true', 'false' ]
        cloud_provider: [ 'aws', 'azure', 'gcp' ]
 

--- a/ClusterTest/build.sbt
+++ b/ClusterTest/build.sbt
@@ -16,8 +16,8 @@
 
 val sparkConnectorVersion = "2.8.5"
 val scalaVersionMajor = "2.12"
-val sparkVersionMajor = "3.0"
-val sparkVersion = s"${sparkVersionMajor}.0"
+val sparkVersionMajor = "3.1"
+val sparkVersion = s"${sparkVersionMajor}.1"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 
 unmanagedJars in Compile += file(s"../target/scala-${scalaVersionMajor}/spark-snowflake_${scalaVersionMajor}-${sparkConnectorVersion}-spark_${sparkVersionMajor}.jar")

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,8 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3.0.0"
-val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
+val sparkVersion = "3.1"
+val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.1.1")
 
 /*
  * Don't change the variable name "sparkConnectorVersion" because
@@ -41,9 +41,9 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
   .settings(
     name := "spark-snowflake",
     organization := "net.snowflake",
-    version := s"${sparkConnectorVersion}-spark_3.0",
+    version := s"${sparkConnectorVersion}-spark_3.1",
     scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = "2.12.11"),
-    // Spark 3.0 only supports scala 2.12
+    // Spark 3.1 only supports scala 2.12
     crossScalaVersions := Seq("2.12.11"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
@@ -54,7 +54,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.1",
       "net.snowflake" % "snowflake-jdbc" % "3.13.2",
       "com.google.guava" % "guava" % "14.0.1" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+      "org.scalatest" %% "scalatest" % "3.1.1" % Test,
       "org.mockito" % "mockito-core" % "1.10.19" % Test,
       "org.apache.commons" % "commons-lang3" % "3.5" % "provided",
       // Below is for Spark Streaming from Kafka test only

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -123,7 +123,7 @@ object SnowflakeFailMessage {
   final val FAIL_PUSHDOWN_SET_TO_EXPR = "pushdown failed in setToExpr"
   final val FAIL_PUSHDOWN_AGGREGATE_EXPRESSION = "pushdown failed for aggregate expression"
   final val FAIL_PUSHDOWN_UNSUPPORTED_CONVERSION = "pushdown failed for unsupported conversion"
-  final val FAIL_PUSHDOWN_UNSUPPORTED_UNION = "pushdown failed for Spark featured UNION"
+  final val FAIL_PUSHDOWN_UNSUPPORTED_UNION = "pushdown failed for Spark feature: UNION by name"
 }
 
 class SnowflakePushdownUnsupportedException(message: String,

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -34,7 +34,7 @@ object SnowflakeConnectorUtils {
     * Check Spark version, if Spark version matches SUPPORT_SPARK_VERSION enable PushDown,
     * otherwise disable it.
     */
-  val SUPPORT_SPARK_VERSION = "3.0"
+  val SUPPORT_SPARK_VERSION = "3.1"
 
   def checkVersionAndEnablePushdown(session: SparkSession): Boolean =
     if (session.version.startsWith(SUPPORT_SPARK_VERSION)) {
@@ -123,6 +123,7 @@ object SnowflakeFailMessage {
   final val FAIL_PUSHDOWN_SET_TO_EXPR = "pushdown failed in setToExpr"
   final val FAIL_PUSHDOWN_AGGREGATE_EXPRESSION = "pushdown failed for aggregate expression"
   final val FAIL_PUSHDOWN_UNSUPPORTED_CONVERSION = "pushdown failed for unsupported conversion"
+  final val FAIL_PUSHDOWN_UNSUPPORTED_UNION = "pushdown failed for Spark featured UNION"
 }
 
 class SnowflakePushdownUnsupportedException(message: String,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
@@ -60,7 +60,8 @@ private[querygeneration] object NumericStatement {
         ConstantString(expr.prettyName.toUpperCase) +
           blockStatement(convertStatements(fields, expr.children: _*))
 
-      case UnaryMinus(child) =>
+      // From spark 3.1, UnaryMinus() has 2 parameters.
+      case UnaryMinus(child, _) =>
         ConstantString("-") +
           blockStatement(convertStatement(child, fields))
 
@@ -87,7 +88,8 @@ private[querygeneration] object NumericStatement {
       // Suppose connector can't see Pi().
       case Pi() => ConstantString("PI()") !
 
-      case Rand(seed) =>
+      // From spark 3.1, Rand() has 2 parameters.
+      case Rand(seed, _) =>
         ConstantString("RANDOM") + blockStatement(
           LongVariable(Option(seed).map(_.asInstanceOf[Long])) !
         )

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
@@ -195,6 +195,8 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) {
 
       // From Spark 3.1, Union has 3 parameters
       case Union(children, byName, allowMissingCol) =>
+        // Snowflake doesn't support Union by Name. For details about what's UNION by Name,
+        // refer to the comment and example at Spark function: DataSet.unionByName()
         if (byName || allowMissingCol) {
           // This exception is not a real issue. It will be caught in
           // QueryBuilder.treeRoot and a telemetry message will be sent if

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
@@ -193,8 +193,21 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) {
           }
         }
 
-      case Union(children) =>
-        Some(UnionQuery(children, alias.next))
+      // From Spark 3.1, Union has 3 parameters
+      case Union(children, byName, allowMissingCol) =>
+        if (byName || allowMissingCol) {
+          // This exception is not a real issue. It will be caught in
+          // QueryBuilder.treeRoot and a telemetry message will be sent if
+          // there are any snowflake tables in the query.
+          throw new SnowflakePushdownUnsupportedException(
+            SnowflakeFailMessage.FAIL_PUSHDOWN_UNSUPPORTED_UNION,
+            s"${plan.nodeName} with byName=$byName allowMissingCol=$allowMissingCol",
+            plan.getClass.getName,
+            false
+          )
+        } else {
+          Some(UnionQuery(children, alias.next))
+        }
 
       case Expand(projections, output, child) =>
         val children = projections.map { p =>


### PR DESCRIPTION
Spark 3.1 has 3 change affects SC pushdown. Below are what's the change and how SC process it.

1. Change constructor for `Union`. It has 2 new parameters: `byName` and `allowMissingCol`. 
    Snowflake doesn’t support this spark featured UNION. SC only pushdown UNION if these 2 parameters are FALSE.
```
case class Union(
    children: Seq[LogicalPlan],
    byName: Boolean = false,
    allowMissingCol: Boolean = false)
```

2. Change constructor for UnaryMinus. It has a new parameters `failOnError`.
    It defines the behaviour for `Minus` operator for spark when error happens. SC can ignore it.
```
case class UnaryMinus(
    child: Expression,
    failOnError: Boolean = SQLConf.get.ansiEnabled)
```

3. Change constructor for Rand . It has a new parameter hideSeed.
    `hideSeed` is used to avoid printing `seed` in the plan. SC can ignore it.
```
case class Rand(child: Expression, hideSeed: Boolean = false)

override def sql: String = {
  s"rand(${if (hideSeed) "" else child.sql})"
}
```
