### PR TITLE
SNOW-297134 Support to write a DataFrame without any partition.

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -32,6 +32,14 @@ trait IntegrationSuiteBase
     extends IntegrationEnv
     with QueryTest {
 
+  /**
+    * A helper object for importing spark SQL implicits.
+    * It is equivalent to org.apache.spark.sql.test.SQLTestUtilsBase.testImplicits
+    */
+  protected object testImplicits extends SQLImplicits {
+    protected override def _sqlContext: SQLContext = sparkSession.sqlContext
+  }
+
   private val log = LoggerFactory.getLogger(getClass)
 
   def getAzureURL(input: String): String = {

--- a/src/it/scala/org/apache/spark/sql/snowflake/SFTestWrapperSparkSession.scala
+++ b/src/it/scala/org/apache/spark/sql/snowflake/SFTestWrapperSparkSession.scala
@@ -1,8 +1,8 @@
 package org.apache.spark.sql.snowflake
 
-import net.snowflake.spark.snowflake.{TestUtils, Utils}
+import net.snowflake.spark.snowflake.Utils
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.{DataFrame, Encoder, SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, Encoder, SparkSession}
 
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Random
@@ -28,10 +28,6 @@ class SFTestWrapperSparkSession(sc: SparkContext, sfConfigs: Map[String, String]
       .options(sfConfigs)
       .option("dbtable", tableName)
       .save()
-    if (df.count() == 0) {
-      val options = sfConfigs ++ Map("dbtable" -> tableName)
-      TestUtils.createTable(df, options , tableName)
-    }
     read
       .format(Utils.SNOWFLAKE_SOURCE_SHORT_NAME)
       .options(sfConfigs)

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -162,6 +162,13 @@ object Parameters {
   val PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY: String = knownParam(
     "internal_check_table_existence_in_current_schema_only"
   )
+  // Internal option to skip write operation when writing a DataFrame
+  // without any partitions. By default, it it is 'false'.
+  // This option may be removed without any notice in any time.
+  // Introduced since Spark Connector 2.8.5
+  val PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME: String = knownParam(
+    "internal_skip_write_when_writing_empty_dataframe"
+  )
 
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
@@ -620,6 +627,9 @@ object Parameters {
     }
     def checkTableExistenceInCurrentSchemaOnly: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY, "true"))
+    }
+    def skipWriteWhenWritingEmptyDataFrame: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME, "false"))
     }
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -225,12 +225,23 @@ private[io] object StageWriter {
           format,
           fileUploadResults
         )
-      } else {
+      } else if (params.skipWriteWhenWritingEmptyDataFrame) {
         log.info(
           s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
              | Skip to execute COPY INTO TABLE command because
              | no file is uploaded.
              |""".stripMargin.filter(_ >= ' '))
+      } else {
+        writeToTable(
+          conn,
+          schema,
+          saveMode,
+          params,
+          "dummy_prefix_for_write_empty_partition",
+          stage,
+          format,
+          fileUploadResults
+        )
       }
       val endTime = System.currentTimeMillis()
 

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -232,16 +232,8 @@ private[io] object StageWriter {
              | no file is uploaded.
              |""".stripMargin.filter(_ >= ' '))
       } else {
-        writeToTable(
-          conn,
-          schema,
-          saveMode,
-          params,
-          "dummy_prefix_for_write_empty_partition",
-          stage,
-          format,
-          fileUploadResults
-        )
+          conn.createTable(params.table.get.name, schema, params,
+            overwrite = saveMode.equals(SaveMode.Overwrite), temporary = false)
       }
       val endTime = System.currentTimeMillis()
 


### PR DESCRIPTION
Description
=========
Below DataFrame doesn't have any partition. Currently, the WRITE operation is skipped when writing it to snowflake.
`val emptyDf = Seq.empty[(Int, String)].toDF("key", "value")
`

Analysis
======
I have confirmed to write this DataFrame as CSV file and Parquet file. It generates an empty file for WRITE operation.
So, we will not skip the WRITE operation either. For example,
1. If the target doesn't exists, it will create an empty table.
2. If the target table exists and write mode is OverWrite, a new table is created to overwrite the old table.

Implementation
===========
1. If the dataframe has no partitions
   a) If save mode is Append, executes `CREATE  TABLE IF  NOT EXISTS ...`  to create table.
   b) If write mode is OverWrite, executes `CREATE OR REPLACE TABLE ...`  to create table.
2. Introduce below internal option to disable this fix to play it safe.
```
  // Internal option to skip write operation when writing a DataFrame
  // without any partitions. By default, it it is 'false'.
  // This option may be removed without any notice in any time.
  // Introduced since Spark Connector 2.8.5
  val PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME: String = knownParam(
    "internal_skip_write_when_writing_empty_dataframe"
  )
```
