### PR TITLE
SNOW-304320 Avoid syntax error when processing pushdown of DataFrame.ropDuplicates()

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement01.scala
@@ -22,6 +22,7 @@ import java.util.TimeZone
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import net.snowflake.spark.snowflake.test.TestHook
 import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
 
 // scalastyle:off println
 class PushdownEnhancement01 extends IntegrationSuiteBase {
@@ -107,6 +108,51 @@ class PushdownEnhancement01 extends IntegrationSuiteBase {
       result,
       expectedResult,
       testPushdownOff = false
+    )
+  }
+
+  test("test/reproduce SNOW-304320: call DataFrame.dropDuplicates(c1)") {
+    jdbcUpdate(s"create or replace table $test_table_length(c1 char(10), c2 varchar(10), c3 string)")
+    jdbcUpdate(s"insert into $test_table_length values ('a', 'b1', 'c1'), ('a', 'b2', 'c2')")
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_length)
+      .load()
+    tmpDF.dropDuplicates("c1").show()
+
+    testPushdown(
+      s"""SELECT * FROM ( $test_table_length ) AS "SF_CONNECTOR_QUERY_ALIAS"""".stripMargin,
+      tmpDF.dropDuplicates("c1"),
+      Seq(Row("a", "b1", "c1"))
+    )
+
+    testPushdown(
+      s"""SELECT * FROM ( $test_table_length ) AS "SF_CONNECTOR_QUERY_ALIAS"""".stripMargin,
+      tmpDF.groupBy(col("c1")).agg(first("c2"), first("c3")),
+      Seq(Row("a", "b1", "c1"))
+    )
+  }
+
+  test("test SNOW-304320") {
+    jdbcUpdate(s"create or replace table $test_table_length(c1 char(10), c2 varchar(10), c3 string)")
+    jdbcUpdate(s"insert into $test_table_length values ('a', 'b1', 'c1'), ('a', 'b2', 'c2')")
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_length)
+      .load()
+
+    testPushdown(
+      s"""SELECT ( "SUBQUERY_0"."C1" ) AS "SUBQUERY_1_COL_0" , ( MIN ( "SUBQUERY_0"."C2" ) )
+         | AS "SUBQUERY_1_COL_1" , ( MAX ( "SUBQUERY_0"."C3" ) ) AS "SUBQUERY_1_COL_2"
+         | FROM ( SELECT * FROM ( $test_table_length ) AS
+         | "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" GROUP BY "SUBQUERY_0"."C1"
+         |""".stripMargin,
+      tmpDF.groupBy(col("c1")).agg(min("c2"), max("c3")),
+      Seq(Row("a", "b1", "c2"))
     )
   }
 

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryHelper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryHelper.scala
@@ -65,11 +65,11 @@ private[querygeneration] case class QueryHelper(
         p.map(
           e =>
             colSet.find(c => c.exprId == e.exprId) match {
-              case Some(a) =>
+              case Some(a) if e.isInstanceOf[AttributeReference] =>
                 AttributeReference(a.name, a.dataType, a.nullable, a.metadata)(
                   a.exprId
                 )
-              case None => e
+              case _ => e
           }
       )
     )


### PR DESCRIPTION
Description
=========
For below use case,  the spark plan is `select c1, first(c2), first(c3) from t1 group by c1`.
But Spark connector pushdown the query as `select c1, c2, c3 from t1 group by c1`. `first()` is missing, so syntax error happens.
```
val df =  spark.sql("select c1, c2, c3 from t1")
df.dropDuplicates("c1").show()
```
The reason why `first()` is ignored is that when `QueryHelper.processedProjections` is generated. 
`e` is an Alias for example `first(C2#2) AS first(C2)#12`, but it has the same exprId with `C2#2`,
so the Alias is converted as a column.
```
  val processedProjections: Option[Seq[NamedExpression]] = projections
    .map(
      p =>
        p.map(
          e =>
            colSet.find(c => c.exprId == e.exprId) match {
              case Some(a) =>
                AttributeReference(a.name, a.dataType, a.nullable, a.metadata)(
                  a.exprId
                )
              case _ => e
          }
      )
    )
    .map(p => renameColumns(p, alias))
```

This issue only happens for the query generated by `dropDuplicates()`. If user input query directly, it is no problem.
For example, the pushdown for below case works well.
```
val df =  spark.sql("select c1, first(c2), first(c3) from t1")
```

Below is the spark code for `dropDuplicates()`.
```
/**
 * Replaces logical [[Deduplicate]] operator with an [[Aggregate]] operator.
 */
object ReplaceDeduplicateWithAggregate extends Rule[LogicalPlan] {
  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
    case Deduplicate(keys, child) if !child.isStreaming =>
      val keyExprIds = keys.map(_.exprId)
      val aggCols = child.output.map { attr =>
        if (keyExprIds.contains(attr.exprId)) {
          attr
        } else {
          Alias(new First(attr).toAggregateExpression(), attr.name)(attr.exprId)
        }
      }
      // SPARK-22951: Physical aggregate operators distinguishes global aggregation and grouping
      // aggregations by checking the number of grouping keys. The key difference here is that a
      // global aggregation always returns at least one row even if there are no input rows. Here
      // we append a literal when the grouping key list is empty so that the result aggregate
      // operator is properly treated as a grouping aggregation.
      val nonemptyKeys = if (keys.isEmpty) Literal(1) :: Nil else keys
      Aggregate(nonemptyKeys, aggCols, child)
  }
}
```

Fix
=======
In `QueryHelper.processedProjections`, it checks exprId to map `AttributeReference`. For this spark bug, the check doesn't work. We can add extra check to workaround this spark bug.

```
            colSet.find(c => c.exprId == e.exprId) match {
              case Some(a) if e.isInstanceOf[AttributeReference] =>
                AttributeReference(a.name, a.dataType, a.nullable, a.metadata)(
                  a.exprId
                )
              case _ => e
```
