### PR TITLE
SNOW-330736 Enable to pushdown EqualNullSafe: operator '<=>'

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/BasicStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/BasicStatement.scala
@@ -9,6 +9,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   BitwiseNot,
   BitwiseOr,
   BitwiseXor,
+  EqualNullSafe,
   Expression,
   Literal,
   Or
@@ -67,6 +68,10 @@ private[querygeneration] object BasicStatement {
       case BitwiseNot(child) =>
         ConstantString("BITNOT") + blockStatement(
           convertStatement(child, fields)
+        )
+      case EqualNullSafe(left, right) =>
+        ConstantString("EQUAL_NULL") + blockStatement(
+          convertStatements(fields, left, right)
         )
       case b: BinaryOperator =>
         blockStatement(


### PR DESCRIPTION
The issue is because Spark `EqualNullSafe:  <=> `is pushdown to snowflake as `<=>`. But snowflake doesn’t support this operator.
Snowflake has equivalent function `EQUAL_NULL(left, right)`. So SC can pushdown `EqualNullSafe` as `EQUAL_NULL(left, right)`. 

