### PR TITLE
SNOW-332466 Disable pushdown for converting from DATE/TIMESTAMP to NUMBER

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -122,6 +122,7 @@ object SnowflakeFailMessage {
   final val FAIL_PUSHDOWN_GENERATE_QUERY = "pushdown failed in generateQueries"
   final val FAIL_PUSHDOWN_SET_TO_EXPR = "pushdown failed in setToExpr"
   final val FAIL_PUSHDOWN_AGGREGATE_EXPRESSION = "pushdown failed for aggregate expression"
+  final val FAIL_PUSHDOWN_UNSUPPORTED_CONVERSION = "pushdown failed for unsupported conversion"
 }
 
 class SnowflakePushdownUnsupportedException(message: String,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
@@ -46,7 +46,24 @@ private[querygeneration] object MiscStatement {
       case Cast(child, t, _) =>
         getCastType(t) match {
           case Some(cast) =>
-            raiseExceptionIfCastIsNotSupported(child.dataType, t)
+            /** For known unsupported data conversion, raise exception to break the pushdown process.
+              * For example, snowflake doesn't support to convert DATE/TIMESTAMP to NUMBER
+              */
+            (child.dataType, t) match {
+              case (_: DateType | _: TimestampType,
+              _: IntegerType | _: LongType | _: FloatType | _: DoubleType | _: DecimalType) => {
+                // This exception will not break the connector. It will be caught in
+                // QueryBuilder.treeRoot and a telemetry message will be sent if
+                // there are any snowflake tables in the query.
+                throw new SnowflakePushdownUnsupportedException(
+                  SnowflakeFailMessage.FAIL_PUSHDOWN_UNSUPPORTED_CONVERSION,
+                  s"Don't support to convert ${child.dataType} column to $t type",
+                  "",
+                  false)
+              }
+              case _ =>
+            }
+
             ConstantString("CAST") +
               blockStatement(convertStatement(child, fields) + "AS" + cast)
           case _ => convertStatement(child, fields)
@@ -160,33 +177,5 @@ private[querygeneration] object MiscStatement {
       case DoubleType => "DOUBLE"
       case _ => null
     })
-
-  /** For known unsupported data conversion, raise exception to break the pushdown process.
-    * For example, snowflake doesn't support to convert DATE/TIMESTAMP to NUMBER
-    */
-  private[querygeneration] def raiseExceptionIfCastIsNotSupported(srcType: DataType, targetType: DataType): Unit = {
-    val isSupported = srcType match {
-      case _: DateType | _: TimestampType =>
-        targetType match {
-          case _: DecimalType | _: IntegerType | _: LongType | _: FloatType | _: DoubleType =>
-            // snowflake doesn't support to convert DATE/TIMESTAMP to NUMBER
-            false
-          case _ => true
-        }
-      case _ => true
-    }
-
-    if (!isSupported) {
-      // This exception will not break the connector. It will be caught in
-      // QueryBuilder.treeRoot and a telemetry message will be sent if
-      // there are any snowflake tables in the query.
-      throw new SnowflakePushdownUnsupportedException(
-        SnowflakeFailMessage.FAIL_PUSHDOWN_UNSUPPORTED_CONVERSION,
-        s"Don't support to convert $srcType column to $targetType type",
-        "",
-        false
-      )
-    }
-  }
 
 }

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -187,6 +187,7 @@ class MiscSuite01 extends FunSuite with Matchers {
     println(SnowflakeFailMessage.FAIL_PUSHDOWN_GENERATE_QUERY)
     println(SnowflakeFailMessage.FAIL_PUSHDOWN_SET_TO_EXPR)
     println(SnowflakeFailMessage.FAIL_PUSHDOWN_STATEMENT)
+    println(SnowflakeFailMessage.FAIL_PUSHDOWN_UNSUPPORTED_CONVERSION)
   }
 
   test("unit test for SnowflakeTelemetry.getClientConfig") {

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -200,6 +200,7 @@ class MiscSuite01 extends FunSuite with Matchers {
       .config("spark.driver.extraJavaOptions", s"-Duser.timezone=GMT")
       .config("spark.executor.extraJavaOptions", s"-Duser.timezone=UTC")
       .config("spark.sql.session.timeZone", "America/Los_Angeles")
+      .config("spark.driver.bindAddress", "127.0.0.1")
       .getOrCreate()
 
     val metric = SnowflakeTelemetry.getClientConfig()

--- a/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
@@ -99,15 +99,14 @@ class UtilsSuite extends FunSuite with Matchers {
   }
 
   test("test Utils.readMapFromFile/readMapFromString") {
-    val conf = new SparkConf()
-      .setMaster("local")
-      .setAppName("SnowflakeSourceSuite")
-    val sc = SparkContext.getOrCreate(conf)
-
     // Test valid map file
     val mapContentString = "#key0 = value0\nkey1=value1\nkey2=value2"
     val (file, fullName, name) = writeTempFile(mapContentString)
     try {
+      val conf = new SparkConf()
+        .setMaster("local")
+        .setAppName("SnowflakeSourceSuite")
+      val sc = SparkContext.getOrCreate(conf)
       val resultMap = Utils.readMapFromFile(sc, fullName)
       assert(resultMap.size == 2)
       assert(resultMap("key1").equals("value1"))


### PR DESCRIPTION
This change doesn't affect functionality.
If the conversion is pushdown to snowflake, snowflake will raise conversion error like below. SC will retry without pushdown. The reading will succeed in the end.
But this change will avoid users see a lot of failed query.
```
SQL compilation error:
invalid type [CAST(SUBQUERY_0.D AS FLOAT)] for parameter 'TO_DOUBLE'
```