### PR TITLE
SNOW-346101 Set client info with JDBC properties instead of system property

### DIFF
--- a/.github/workflows/ClusterTest.yml
+++ b/.github/workflows/ClusterTest.yml
@@ -23,7 +23,7 @@ jobs:
         TEST_SCALA_VERSION: '2.12'
         TEST_COMPILE_SCALA_VERSION: '2.12.11'
         TEST_SPARK_CONNECTOR_VERSION: '2.8.6'
-        TEST_JDBC_VERSION: '3.13.2'
+        TEST_JDBC_VERSION: '3.13.3'
 
     steps:
     - uses: actions/checkout@v2

--- a/ClusterTest/build.sbt
+++ b/ClusterTest/build.sbt
@@ -36,7 +36,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.1",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.2",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.3",
       // "net.snowflake" %% "spark-snowflake" % "2.8.0-spark_3.0",
       // "com.google.guava" % "guava" % "14.0.1" % Test,
       // "org.scalatest" %% "scalatest" % "3.0.5" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.1",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.2",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.3",
       "com.google.guava" % "guava" % "14.0.1" % Test,
       "org.scalatest" %% "scalatest" % "3.1.1" % Test,
       "org.mockito" % "mockito-core" % "1.10.19" % Test,

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -41,6 +41,8 @@ object SnowflakeConnectorUtils {
       enablePushdownSession(session)
       true
     } else {
+      log.warn("Don't support query pushdown because the Spark Connector is built for " +
+        s"Spark $SUPPORT_SPARK_VERSION, but this Spark version is ${session.version}")
       disablePushdownSession(session)
       false
     }

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -24,6 +24,7 @@ import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, ThreadFactory}
 
+import net.snowflake.client.core.SFSessionProperty
 import net.snowflake.client.jdbc.telemetry.{Telemetry, TelemetryClient}
 import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
@@ -199,9 +200,11 @@ private[snowflake] class JDBCWrapper {
            |""".stripMargin.filter(_ >= ' '))
     }
 
-    // Important: Set "snowflake.client.info" is very important!
+    // Important: Set client_info is very important!
     // For more details, refer to PROPERTY_NAME_OF_CONNECTOR_VERSION
-    System.setProperty("snowflake.client.info", Utils.getClientInfoString())
+    // NOTE: From JDBC 3.13.3, the client info can be set with JDBC properties
+    // instead of system property: "snowflake.client.info".
+    jdbcProperties.put(SFSessionProperty.CLIENT_INFO.getPropertyKey, Utils.getClientInfoString())
 
     val conn: Connection = DriverManager.getConnection(jdbcURL, jdbcProperties)
 

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -59,7 +59,7 @@ object Utils {
   /**
     * The certified JDBC version to work with this spark connector version.
     */
-  val CERTIFIED_JDBC_VERSION = "3.13.2"
+  val CERTIFIED_JDBC_VERSION = "3.13.3"
 
   /**
     * Important:


### PR DESCRIPTION
Currently, Spark connector uses system property to set CLIENT INFO. But this is not reliable in some cases, for example, the user may have no privilege to set system property.

From JDBC 3.13.3, JDBC supports to set CLIENT INFO with JDBC properties.
So, update Spark connector to set it in JDBC properties.

In the same time, bump JDBC version to latest 3.13.3. 