### PR TITLE
SNOW-370053 Fix one pushdown issue for LIMIT + SORT.

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
@@ -153,10 +153,10 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) {
               ProjectQuery(fields, subQuery, alias.next)
             case Aggregate(groups, fields, _) =>
               AggregateQuery(fields, groups, subQuery, alias.next)
-            case Limit(limitExpr, _) =>
-              SortLimitQuery(Some(limitExpr), Seq.empty, subQuery, alias.next)
             case Limit(limitExpr, Sort(orderExpr, true, _)) =>
               SortLimitQuery(Some(limitExpr), orderExpr, subQuery, alias.next)
+            case Limit(limitExpr, _) =>
+              SortLimitQuery(Some(limitExpr), Seq.empty, subQuery, alias.next)
 
             case Sort(orderExpr, true, Limit(limitExpr, _)) =>
               SortLimitQuery(Some(limitExpr), orderExpr, subQuery, alias.next)


### PR DESCRIPTION
In order to make sure SORT + LIMIT to return a deterministic result, spark connector needs special handling for SORT + LIMIT to make SORT and LIMIT to be in the same level.  For more details about why they should be in the same level, refer to below document.
1. https://community.snowflake.com/s/article/SELECT-query-with-LIMIT-clause-returns-non-deterministic-result-if-ORDER-BY-clause-exists-in-different-level
2. https://mariadb.com/kb/en/why-is-order-by-in-a-from-subquery-ignored/

But, there is a typo in spark connector pushdown processing which causes the special handling not to be used. This PR is to enable it.

Below `case Limit(limitExpr, Sort(orderExpr, true, _))` is used to handle the special case of SORT + LIMIT, but it is located after `case Limit(limitExpr, _)`. So, it is never used. Exchanging their order can make sure the special handling to be enabled.
```
            case Limit(limitExpr, _) =>
              SortLimitQuery(Some(limitExpr), Seq.empty, subQuery, alias.next)
            case Limit(limitExpr, Sort(orderExpr, true, _)) =>
              SortLimitQuery(Some(limitExpr), orderExpr, subQuery, alias.next)
```

Add one test case with large table for this case.

NOTE:
Michael has a great analysis for this issue. FYI.  https://github.com/snowflakedb/spark-snowflake/issues/364