### PR TITLE
SNOW-360268 Remove the '-e' option for deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Push the Spark Connector to the public maven repository
 # This script needs to be executed by snowflake jenkins job


### PR DESCRIPTION
SNOW-360268

This build script can't run because of `-e` option. 
With `-e`, the script quits because `which sbt` can't find `sbt`.
For details about `-e`, refer to https://tldp.org/LDP/abs/html/options.html