### PR TITLE
SNOW-474215 Add 3 options to set 3 timestamp output formats

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -2212,6 +2212,21 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
       .save()
   }
 
+  test("if timezone and timestamp output formats are sf_current, they are not set") {
+    var sfOptions = thisConnectorOptionsNoTable
+    sfOptions += (Parameters.PARAM_SF_TIMEZONE -> "sf_current")
+    sfOptions += (Parameters.PARAM_TIMESTAMP_NTZ_OUTPUT_FORMAT -> "sf_current")
+    sfOptions += (Parameters.PARAM_TIMESTAMP_LTZ_OUTPUT_FORMAT -> "sf_current")
+    sfOptions += (Parameters.PARAM_TIMESTAMP_TZ_OUTPUT_FORMAT -> "sf_current")
+
+    sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(sfOptions)
+      .option("query", s"select current_timestamp()")
+      .load()
+      .collect()
+  }
+
   override def beforeEach(): Unit = {
     super.beforeEach()
   }

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -111,6 +111,10 @@ object Parameters {
     "partition_size_in_mb"
   )
   val PARAM_TIME_OUTPUT_FORMAT: String = knownParam("time_output_format")
+  val PARAM_TIMESTAMP_NTZ_OUTPUT_FORMAT: String = knownParam("timestamp_ntz_output_format")
+  val PARAM_TIMESTAMP_LTZ_OUTPUT_FORMAT: String = knownParam("timestamp_ltz_output_format")
+  val PARAM_TIMESTAMP_TZ_OUTPUT_FORMAT: String = knownParam("timestamp_tz_output_format")
+  val TIMESTAMP_OUTPUT_FORMAT_SF_CURRENT: String = "sf_current"
   val PARAM_JDBC_QUERY_RESULT_FORMAT: String = knownParam(
     "jdbc_query_result_format"
   )
@@ -215,7 +219,10 @@ object Parameters {
     PARAM_MAX_RETRY_COUNT -> "10",
     PARAM_USE_EXPONENTIAL_BACKOFF -> "off",
     PARAM_UPLOAD_CHUNK_SIZE_IN_MB -> "8",
-    PARAM_USE_AWS_MULTIPLE_PARTS_UPLOAD -> "true"
+    PARAM_USE_AWS_MULTIPLE_PARTS_UPLOAD -> "true",
+    PARAM_TIMESTAMP_NTZ_OUTPUT_FORMAT -> "YYYY-MM-DD HH24:MI:SS.FF3",
+    PARAM_TIMESTAMP_LTZ_OUTPUT_FORMAT -> "TZHTZM YYYY-MM-DD HH24:MI:SS.FF3",
+    PARAM_TIMESTAMP_TZ_OUTPUT_FORMAT -> "TZHTZM YYYY-MM-DD HH24:MI:SS.FF3"
   )
 
   /**
@@ -612,6 +619,15 @@ object Parameters {
     def expectedPartitionCount: Int = {
       parameters.getOrElse(PARAM_EXPECTED_PARTITION_COUNT, "1000").toInt
     }
+
+    def sfTimestampNTZOutputFormat: Option[String] =
+      parameters.get(PARAM_TIMESTAMP_NTZ_OUTPUT_FORMAT)
+    def sfTimestampLTZOutputFormat: Option[String] =
+      parameters.get(PARAM_TIMESTAMP_LTZ_OUTPUT_FORMAT)
+    def sfTimestampTZOutputFormat: Option[String] =
+      parameters.get(PARAM_TIMESTAMP_TZ_OUTPUT_FORMAT)
+    def isTimestampSnowflake(timestampFormat: String): Boolean =
+      TIMESTAMP_OUTPUT_FORMAT_SF_CURRENT.equals(timestampFormat)
 
     def maxRetryCount: Int = {
       parameters.getOrElse(PARAM_MAX_RETRY_COUNT, "10").toInt

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -182,7 +182,7 @@ private[snowflake] case class SnowflakeRelation(
     resultSchema: StructType
   ): RDD[T] = {
     val conn = DefaultJDBCWrapper.getConnector(params)
-    Utils.genPrologueSql(params).execute(bindVariableEnabled = false)(conn)
+    Utils.genPrologueSql(params).foreach(x => x.execute(bindVariableEnabled = false)(conn))
     Utils.executePreActions(DefaultJDBCWrapper, conn, params, params.table)
     Utils.setLastSelect(statement.toString)
 

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
@@ -30,7 +30,7 @@ private[snowflake] object StageReader {
     val compress = params.sfCompress
     val compressFormat = if (params.sfCompress) "gzip" else "none"
 
-    Utils.genPrologueSql(params).execute(params.bindVariableEnabled)(conn)
+    Utils.genPrologueSql(params).foreach(x => x.execute(params.bindVariableEnabled)(conn))
 
     Utils.executePreActions(DefaultJDBCWrapper, conn, params, params.table)
 

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -204,7 +204,7 @@ private[io] object StageWriter {
     val conn = DefaultJDBCWrapper.getConnector(params)
 
     try {
-      prologueSql.execute(params.bindVariableEnabled)(conn)
+      prologueSql.foreach(x => x.execute(params.bindVariableEnabled)(conn))
 
       val (storage, stage) = CloudStorageOperations.createStorageClient(
         params, conn, tempStage = true, None, "load")

--- a/src/test/scala/net/snowflake/spark/snowflake/MockSF.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MockSF.scala
@@ -154,15 +154,4 @@ class MockSF(params: Map[String, String],
       )
     }
   }
-
-  def verifyThatExpectedQueriesWereIssuedForUnload(
-    expectedQueries: Seq[Regex]
-  ): Unit = {
-    val queriesWithPrologueAndEpilogue = Seq(
-      Utils.genPrologueSql(mergedParams).toString.r
-    ) ++
-      expectedQueries
-    verifyThatExpectedQueriesWereIssued(queriesWithPrologueAndEpilogue)
-  }
-
 }


### PR DESCRIPTION
SNOW-474215

Issue description
============
CTC raises a concern that SC always executes an `alter session` to set timestamp formats when a JDBC connection is created even if they think they don't need these settings. For example,
```
alter session set timezone = 'GMT' ,
 timestamp_ntz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF3',
 timestamp_ltz_output_format = 'TZHTZM YYYY-MM-DD HH24:MI:SS.FF3',
 timestamp_tz_output_format = 'TZHTZM YYYY-MM-DD HH24:MI:SS.FF3' ; 
```

Fix
==
Add 3 spark connector options to set these 3 output format.
1. Their default value is current settings, so it doesn't break any customer
2. User has a choice to set these options if they need.
3. If these 3 options and `sfTimezone` are set as `sf_current`, the `alter session` command can be skipped. This can satisfy CTC's use case.
```
option_name -> default_value
========================
timestamp_ntz_output_format -> "YYYY-MM-DD HH24:MI:SS.FF3"
timestamp_ltz_output_format -> "TZHTZM YYYY-MM-DD HH24:MI:SS.FF3"
timestamp_tz_output_format  -> "TZHTZM YYYY-MM-DD HH24:MI:SS.FF3"
```