### PR TITLE
Support to count large table

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -1193,6 +1193,17 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
     assert(count == LARGE_TABLE_ROW_COUNT)
   }
 
+  test("count super large table") {
+    if (!skipBigDataTest) {
+      val expectedCount = Int.MaxValue + 1L
+      val actualCount = getRowCount(
+        s"table(generator(rowcount => $expectedCount))",
+        thisConnectorOptionsNoTable
+      )
+      assert(actualCount == expectedCount)
+    }
+  }
+
   // Copy one table from AWS account to GCP account
   ignore("copy data from AWS to GCP") {
     val moveTableName = "LINEITEM_FROM_PARQUET"

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -1196,10 +1196,12 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
   test("count super large table") {
     if (!skipBigDataTest) {
       val expectedCount = Int.MaxValue + 1L
-      val actualCount = getRowCount(
-        s"table(generator(rowcount => $expectedCount))",
-        thisConnectorOptionsNoTable
-      )
+      val actualCount = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(thisConnectorOptionsNoTable)
+        .option("query", s"select 1 from table(generator(rowcount => $expectedCount))")
+        .load()
+        .count()
       assert(actualCount == expectedCount)
     }
   }

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -130,7 +130,7 @@ private[snowflake] case class SnowflakeRelation(
             sqlContext.getConf("spark.sql.shuffle.partitions", "200").toInt
           val emptyRow = Row.empty
           sqlContext.sparkContext
-            .parallelize(1L to numRows, parallelism)
+            .range(start = 0L, end = numRows, numSlices = parallelism)
             .map(_ => emptyRow)
         } else {
           throw new IllegalStateException("Could not read count from Snowflake")


### PR DESCRIPTION
fixes #376

SparkContext.parallelize() doesn't support Int64, instead of which we can use SparkContext.range()