### PR TITLE
SNOW-475356 Add 2 fields to client_info and send it per connection

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -230,7 +230,7 @@ private[snowflake] class JDBCWrapper {
 
     // Send client info telemetry message.
     val extraValues = Map(TelemetryClientInfoFields.SFURL -> sfURL)
-    SnowflakeTelemetry.sendClientInfoTelemetryIfNotYet(extraValues, conn)
+    SnowflakeTelemetry.sendClientInfoTelemetry(extraValues, conn)
 
     conn
   }

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -27,6 +27,7 @@ import net.snowflake.client.jdbc.internal.amazonaws.ClientConfiguration
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode
 import net.snowflake.client.jdbc.internal.microsoft.azure.storage.OperationContext
+import org.apache.spark.SparkEnv
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{FunSuite, Matchers}
 
@@ -208,6 +209,9 @@ class MiscSuite01 extends FunSuite with Matchers {
     assert(metric.get(TelemetryClientInfoFields.SPARK_CONNECTOR_VERSION).asText().equals(Utils.VERSION))
     // check one JVM option
     assert(metric.get(TelemetryClientInfoFields.MAX_MEMORY_IN_MB).asLong() > 0)
+    assert(metric.get(TelemetryClientInfoFields.SPARK_APPLICATION_ID).asText().equals(
+      SparkEnv.get.conf.get("spark.app.id")))
+    assert(!metric.get(TelemetryClientInfoFields.IS_PYSPARK).asBoolean())
     // check Spark options
     val sparkConfNode = metric.get(TelemetryClientInfoFields.SPARK_CONFIG)
     assert(sparkConfNode.get("spark.master").asText().equals("local"))


### PR DESCRIPTION
SNOW-475356
Add below 2 fields to spark connector client_info telemetry. And change to send this message per JDBC connection instead of per JVM.
1. Add `spark_application_id` for spark application ID
2. Add `is_pyspark` for whether it is submitted by pyspark.

