### PR TITLE
SNOW-495389 Support to write empty DataFrame without CREATE TABLE permission if possible.

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -463,7 +463,7 @@ class TruncateTableSuite extends IntegrationSuiteBase {
     assert(readDF.count() == 0 && readDF.schema.fields.length == 2)
   }
 
-  test("Write empty DataFrame and target table doesn't exist: SNOW-495389") {
+  test("Write empty DataFrame and target table exists: SNOW-495389") {
     import testImplicits._
     val emptyDf = Seq.empty[(Int, String)].toDF("key", "value")
     // Create target table
@@ -480,33 +480,14 @@ class TruncateTableSuite extends IntegrationSuiteBase {
       .mode(SaveMode.Overwrite)
       .save()
 
-    // target table is empty, and table is not recreated.
+    // target table is empty, and table is not re-created.
     assert(sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable)
       .option("query", s"select c1 from $targetTable") // "c1" is old table column name
       .load().count() == 0)
 
-    // case 2: Write DF with Overwrite, truncate_table = on, and usestagingtable = off
-    // But disable the fix
-    emptyDf.write
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(connectorOptionsNoTable)
-      .option("dbtable", targetTable)
-      .option("truncate_table", "on")
-      .option("usestagingtable", "off")
-      .option(Parameters.PARAM_INTERNAL_USE_COPY_TO_WRITE_EMPTY_DATAFRAME, "false")
-      .mode(SaveMode.Overwrite)
-      .save()
-
-    // If this fix is disabled, the table will be recreated.
-    assert(sparkSession.read
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(connectorOptionsNoTable)
-      .option("query", s"select key from $targetTable") // "key" is old table column name
-      .load().count() == 0)
-
-    // case 3: Write DF with Overwrite, truncate_table = off, and usestagingtable = off
+    // case 2: Write DF with Overwrite, truncate_table = off, and usestagingtable = off
     jdbcUpdate(s"create or replace table $targetTable (c1 int, c2 string)")
     jdbcUpdate(s"insert into $targetTable values (123, 'abc')")
     emptyDf.write

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -173,6 +173,13 @@ object Parameters {
   val PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME: String = knownParam(
     "internal_skip_write_when_writing_empty_dataframe"
   )
+  // Internal option to use COPY command to write a DataFrame
+  // without any partitions. By default, it is 'true'.
+  // This option may be removed without any notice in any time.
+  // Introduced since Spark Connector 2.9.3
+  val PARAM_INTERNAL_USE_COPY_TO_WRITE_EMPTY_DATAFRAME: String = knownParam(
+    "internal_use_copy_to_write_empty_dataframe"
+  )
 
   // Internal option to use sync mode to execute query and COPY INTO TABLE command.
   // By default, it it is 'false'.
@@ -665,6 +672,9 @@ object Parameters {
     }
     def skipWriteWhenWritingEmptyDataFrame: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME, "false"))
+    }
+    def useCopyToWriteEmptyDataFrame: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_COPY_TO_WRITE_EMPTY_DATAFRAME, "true"))
     }
     def isExecuteQueryWithSyncMode: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_EXECUTE_QUERY_IN_SYNC_MODE, "false"))

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -173,13 +173,6 @@ object Parameters {
   val PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME: String = knownParam(
     "internal_skip_write_when_writing_empty_dataframe"
   )
-  // Internal option to use COPY command to write a DataFrame
-  // without any partitions. By default, it is 'true'.
-  // This option may be removed without any notice in any time.
-  // Introduced since Spark Connector 2.9.3
-  val PARAM_INTERNAL_USE_COPY_TO_WRITE_EMPTY_DATAFRAME: String = knownParam(
-    "internal_use_copy_to_write_empty_dataframe"
-  )
 
   // Internal option to use sync mode to execute query and COPY INTO TABLE command.
   // By default, it it is 'false'.
@@ -672,9 +665,6 @@ object Parameters {
     }
     def skipWriteWhenWritingEmptyDataFrame: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME, "false"))
-    }
-    def useCopyToWriteEmptyDataFrame: Boolean = {
-      isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_COPY_TO_WRITE_EMPTY_DATAFRAME, "true"))
     }
     def isExecuteQueryWithSyncMode: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_EXECUTE_QUERY_IN_SYNC_MODE, "false"))

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -236,7 +236,7 @@ private[io] object StageWriter {
              | Skip to execute COPY INTO TABLE command because
              | no file is uploaded.
              |""".stripMargin.filter(_ >= ' '))
-      } else if (params.useCopyToWriteEmptyDataFrame) {
+      } else {
         log.info(
           s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
              | use dummy prefix to handle the special case that no file is uploaded.
@@ -252,13 +252,6 @@ private[io] object StageWriter {
           format,
           fileUploadResults // empty file
         )
-      } else {
-        log.info(
-          s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
-             | use CREATE TABLE directly to handle the special case that no file is uploaded.
-             |""".stripMargin.filter(_ >= ' '))
-          conn.createTable(params.table.get.name, schema, params,
-            overwrite = saveMode.equals(SaveMode.Overwrite), temporary = false)
       }
       val endTime = System.currentTimeMillis()
 

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -236,7 +236,27 @@ private[io] object StageWriter {
              | Skip to execute COPY INTO TABLE command because
              | no file is uploaded.
              |""".stripMargin.filter(_ >= ' '))
+      } else if (params.useCopyToWriteEmptyDataFrame) {
+        log.info(
+          s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
+             | use dummy prefix to handle the special case that no file is uploaded.
+             |""".stripMargin.filter(_ >= ' '))
+        writeToTable(
+          sqlContext,
+          conn,
+          schema,
+          saveMode,
+          params,
+          s"dummy_not_exist_prefix_${Math.abs(Random.nextLong()).toString}",
+          stage,
+          format,
+          fileUploadResults // empty file
+        )
       } else {
+        log.info(
+          s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
+             | use CREATE TABLE directly to handle the special case that no file is uploaded.
+             |""".stripMargin.filter(_ >= ' '))
           conn.createTable(params.table.get.name, schema, params,
             overwrite = saveMode.equals(SaveMode.Overwrite), temporary = false)
       }


### PR DESCRIPTION
SNOW-495389 Support to write empty DataFrame without CREATE TABLE permission if possible.

Issue description
=============
Currently, when spark connector writes an empty DataFrame (without any partition), it executes a CREATE TABLE AS SELECT command. In most case, there is no problem because the user needs to have CREATE TABLE privilege.
But in below special case, the user actually doesn't need CREATE TABLE privilege.
1. truncate_table = on
2. usestagingtable = off
3. target table already exists.

Fixing
=====
The fix is to make the DataFrame write to go through the normal DataFrame process instead of executing CTAS for this special case. The original reason to use CTAS is that there is no file uploading happen, the driver can't get a stage prefix. It can be workaround by using a dummy prefix.