### PR TITLE
SNOW-489598 Support writing for snowflake account with FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS enabled

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
@@ -372,7 +372,9 @@ class StageSuite extends IntegrationSuiteBase {
         param.useExponentialBackoff,
         param.expectedPartitionCount,
         pref = "test_dir",
-        connection = connection
+        connection = connection,
+        useRegionUrl = None,
+        regionName = None
       )
 
       assertThrows[Exception]({
@@ -489,7 +491,9 @@ class StageSuite extends IntegrationSuiteBase {
         param.useExponentialBackoff,
         param.expectedPartitionCount,
         pref = "test_dir",
-        connection = connection
+        connection = connection,
+        useRegionUrl = None,
+        regionName = None
       )
 
       val storageInfo: Map[String, String] = Map()

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -183,6 +183,13 @@ object Parameters {
     "internal_execute_query_in_sync_mode"
   )
 
+  // Internal option to use AWS region URL. By default, it is 'true'.
+  // This option may be removed without any notice in any time.
+  // Introduced since Spark Connector 2.9.3
+  val PARAM_INTERNAL_USE_AWS_REGION_URL: String = knownParam(
+    "internal_use_aws_region_url"
+  )
+
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
 
@@ -643,6 +650,9 @@ object Parameters {
     }
     def useExponentialBackoff: Boolean = {
       isTrue(parameters.getOrElse(PARAM_USE_EXPONENTIAL_BACKOFF, "false"))
+    }
+    def useAWSRegionURL: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_AWS_REGION_URL, "true"))
     }
     def stagingTableNameRemoveQuotesOnly: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY, "false"))

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SFInternalStage.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SFInternalStage.scala
@@ -165,4 +165,11 @@ private[io] class SFInternalStage(isWrite: Boolean,
 
   private[io] def getEncryptionMaterials = encryptionMaterials
 
+  // Determine whether to use URL with region name in the same logic as JDBC,
+  // refer to StorageClientFactory.createClient() for details.
+  private[io] def useS3RegionalUrl: Boolean =
+    sfAgent.getStageInfo.getUseS3RegionalUrl ||
+      connection.getSFBaseSession.getUseRegionalS3EndpointsForPresignedURL
+
+  private[io] def getRegion: String = sfAgent.getStageInfo.getRegion
 }


### PR DESCRIPTION
Description
=========
The customer reported that if `FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS` is enabled for their account,
the failed to write a DataFrame to a table in snowflake database.

Analysis and fix
============
According to the stacktrace, the error happens when spark connector worker uploading files to internal stage.
But the user can upload data with JDBC. If `FORCE_REGIONAL_S3_ENDPOINTS_FOR_PRESIGNED_URLS` is enabled,
JDBC did special handle to upload file. In general, JDBC use region name in the pre-signed URL to upload to it.
Below is the related code segment in JDBC `SnowflakeS3Client.setupSnowflakeS3Client()`:
```
      Region region = RegionUtils.getRegion(stageRegion);
      if (region != null) {
        if (this.isUseS3RegionalUrl) {
          amazonS3Builder.withEndpointConfiguration(
              new AwsClientBuilder.EndpointConfiguration(
                  "s3." + region.getName() + ".amazonaws.com", region.getName()));
        } else {
          amazonS3Builder.withRegion(region.getName());
        }
      }
```
So, SC need to enhance do the same kind of special handle for it. Main changes are:
1. Introduce internal option `internal_use_aws_region_url` which can disable this fix if necessary.
2. In SC driver, retrieve `regionName` and `useS3RegionUrl` from the JDBC connection, and pass them to SC executor
3. In SC executor, when I create S3Client, it do the same thing like JDBC.
Note: Only apply this change for S3 internal stage.