### PR TITLE
SNOW-614357 Support JDBC datatype TIMESTAMP_WITH_TIMEZONE

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -461,6 +461,7 @@ private[snowflake] class JDBCWrapper {
       case java.sql.Types.STRUCT    => StringType // Snowflake-todo: ?
       case java.sql.Types.TIME      => StringType
       case java.sql.Types.TIMESTAMP => TimestampType
+      case java.sql.Types.TIMESTAMP_WITH_TIMEZONE => TimestampType
       case java.sql.Types.TINYINT   => IntegerType
       //      case java.sql.Types.VARBINARY     => BinaryType
       case java.sql.Types.VARCHAR => StringType


### PR DESCRIPTION
JDBC only changes the returned datatype, it doesn't change how to get the value from ResultSet.
So SC only needs to support the new type when resolving the schema.