### PR TITLE
SNOW-624169 Spark 3.3 support

### DIFF
--- a/.github/docker/build_image.sh
+++ b/.github/docker/build_image.sh
@@ -33,8 +33,8 @@ cd ../..
 
 # Build docker image
 docker build \
---build-arg SPARK_URL=https://archive.apache.org/dist/spark/spark-3.2.0/spark-3.2.0-bin-hadoop2.7.tgz \
---build-arg SPARK_BINARY_NAME=spark-3.2.0-bin-hadoop2.7.tgz \
+--build-arg SPARK_URL=https://archive.apache.org/dist/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz \
+--build-arg SPARK_BINARY_NAME=spark-3.3.0-bin-hadoop3.tgz \
 --build-arg JDBC_URL=https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/${TEST_JDBC_VERSION}/$JDBC_JAR_NAME \
 --build-arg JDBC_BINARY_NAME=$JDBC_JAR_NAME \
 --build-arg SPARK_CONNECTOR_LOCATION=target/scala-${TEST_SCALA_VERSION}/$SPARK_CONNECTOR_JAR_NAME \

--- a/.github/workflows/ClusterTest.yml
+++ b/.github/workflows/ClusterTest.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       matrix:
         scala_version: [ '2.12.11' ]
-        spark_version: [ '3.2.0' ]
+        spark_version: [ '3.3.0' ]
         use_copy_unload: [ 'true' ]
         cloud_provider: [ 'gcp' ]
     env:
         SNOWFLAKE_TEST_CONFIG_SECRET: ${{ secrets.SNOWFLAKE_TEST_CONFIG_SECRET }}
-        TEST_SPARK_VERSION: '3.2'
-        DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.2.0'
+        TEST_SPARK_VERSION: '3.3'
+        DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.3.0'
         TEST_SCALA_VERSION: '2.12'
         TEST_COMPILE_SCALA_VERSION: '2.12.11'
         TEST_SPARK_CONNECTOR_VERSION: '2.10.1'

--- a/.github/workflows/IntegrationTest_2.12.yml
+++ b/.github/workflows/IntegrationTest_2.12.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.12.11' ]
-       spark_version: [ '3.2.0' ]
+       spark_version: [ '3.3.0' ]
        use_copy_unload: [ 'true', 'false' ]
        cloud_provider: [ 'aws', 'azure' ]
        # run_query_in_async can be removed after async mode is stable

--- a/.github/workflows/IntegrationTest_2.13.yml
+++ b/.github/workflows/IntegrationTest_2.13.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.13.7' ]
-       spark_version: [ '3.2.0' ]
+       spark_version: [ '3.3.0' ]
        use_copy_unload: [ 'true', 'false' ]
        cloud_provider: [ 'aws', 'azure' ]
        # run_query_in_async can be removed after async mode is stable

--- a/.github/workflows/IntegrationTest_gcp_2.12.yml
+++ b/.github/workflows/IntegrationTest_gcp_2.12.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.12.11' ]
-       spark_version: [ '3.2.0' ]
+       spark_version: [ '3.3.0' ]
        use_copy_unload: [ 'false' ]
        cloud_provider: [ 'gcp' ]
        # run_query_in_async can be removed after async mode is stable

--- a/.github/workflows/IntegrationTest_gcp_2.13.yml
+++ b/.github/workflows/IntegrationTest_gcp_2.13.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.13.7' ]
-       spark_version: [ '3.2.0' ]
+       spark_version: [ '3.3.0' ]
        use_copy_unload: [ 'false' ]
        cloud_provider: [ 'gcp' ]
        # run_query_in_async can be removed after async mode is stable

--- a/ClusterTest/build.sbt
+++ b/ClusterTest/build.sbt
@@ -16,7 +16,7 @@
 
 val sparkConnectorVersion = "2.10.1"
 val scalaVersionMajor = "2.12"
-val sparkVersionMajor = "3.2"
+val sparkVersionMajor = "3.3"
 val sparkVersion = s"${sparkVersionMajor}.0"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,8 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3.2"
-val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.2.0")
+val sparkVersion = "3.3"
+val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.3.0")
 
 /*
  * Don't change the variable name "sparkConnectorVersion" because
@@ -41,7 +41,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
   .settings(
     name := "spark-snowflake",
     organization := "net.snowflake",
-    version := s"${sparkConnectorVersion}-spark_3.2",
+    version := s"${sparkConnectorVersion}-spark_3.3",
     scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = "2.12.11"),
     // Spark 3.2 supports scala 2.12 and 2.13
     crossScalaVersions := Seq("2.12.11", "2.13.7"),

--- a/src/it/resources/log4j2.properties
+++ b/src/it/resources/log4j2.properties
@@ -1,0 +1,42 @@
+# Set everything to be logged to the console
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = console
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+
+logger.repl.name = org.apache.spark.repl.Main
+logger.repl.level = warn
+
+logger.thriftserver.name = org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver
+logger.thriftserver.level = warn
+
+# Settings to quiet third party logs that are too verbose
+logger.jetty1.name = org.sparkproject.jetty
+logger.jetty1.level = warn
+logger.jetty2.name = org.sparkproject.jetty.util.component.AbstractLifeCycle
+logger.jetty2.level = error
+logger.replexprTyper.name = org.apache.spark.repl.SparkIMain$exprTyper
+logger.replexprTyper.level = info
+logger.replSparkILoopInterpreter.name = org.apache.spark.repl.SparkILoop$SparkILoopInterpreter
+logger.replSparkILoopInterpreter.level = info
+logger.parquet1.name = org.apache.parquet
+logger.parquet1.level = error
+logger.parquet2.name = parquet
+logger.parquet2.level = error
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+logger.RetryingHMSHandler.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
+logger.RetryingHMSHandler.level = fatal
+logger.FunctionRegistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
+logger.FunctionRegistry.level = error
+
+# For deploying Spark ThriftServer
+# SPARK-34128: Suppress undesirable TTransportException warnings involved in THRIFT-4805
+appender.console.filter.1.type = RegexFilter
+appender.console.filter.1.regex = .*Thrift error occurred during processing of message.*
+appender.console.filter.1.onMatch = deny
+appender.console.filter.1.onMismatch = neutral

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationEnv.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationEnv.scala
@@ -25,6 +25,11 @@ import java.util.TimeZone
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import org.apache.log4j.PropertyConfigurator
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.{Appender, LoggerContext}
+import org.apache.logging.log4j.core.appender.FileAppender
+import org.apache.logging.log4j.core.config.AbstractConfiguration
+import org.apache.logging.log4j.core.layout.PatternLayout
 import org.apache.spark.sql._
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite}
@@ -54,10 +59,55 @@ trait IntegrationEnv
 
   protected val DEFAULT_LOG4J_PROPERTY = "src/it/resources/log4j_default.properties"
 
+  // From spark 3.3, log4j2 is used. For spark 3.2 and older versions, log4j is used.
+  protected val USE_LOG4J2_PROPERTIES = true
+
+  // Reconfigure log4j logging for the test of spark 3.2 and older versions
   protected def reconfigureLogFile(propertyFileName: String): Unit = {
     // Load the log properties for the security test to output more info
     val log4jfile = new File(propertyFileName)
     PropertyConfigurator.configure(log4jfile.getAbsolutePath)
+  }
+
+  // Reconfigure log4j2 log level for the test of spark 3.3 and newer versions
+  protected def reconfigureLog4j2LogLevel(logLevel: Level): Unit = {
+    import org.apache.logging.log4j.LogManager
+    val ctx = LogManager.getContext(false).asInstanceOf[LoggerContext]
+    val config = ctx.getConfiguration
+    val loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME)
+    log.warn(s"reconfigure log level as $logLevel")
+    loggerConfig.setLevel(logLevel)
+    ctx.updateLoggers()
+  }
+
+  // Add a log4j2 FileAppender for the test of spark 3.3 and newer versions
+  protected def addLog4j2FileAppender(filePath: String, appenderName: String): Unit = {
+    val ctx = LogManager.getContext(false).asInstanceOf[LoggerContext]
+    val config = ctx.getConfiguration
+    val loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME)
+
+    val layout = PatternLayout.createDefaultLayout(config)
+
+    val appender: Appender = FileAppender.createAppender(
+      filePath, "false", "false", appenderName,
+      "true", "false", "false", "4000",
+      layout, null, "false", null, config)
+
+    appender.start()
+    config.addAppender(appender)
+    loggerConfig.addAppender(appender, null, null)
+    config.addLogger("org.apache.logging.log4j", loggerConfig)
+    ctx.updateLoggers()
+  }
+
+  // Drop a log4j2 FileAppender for the test of spark 3.3 and newer versions
+  protected def dropLog4j2FileAppender(appenderName: String): Unit = {
+    val ctx = LogManager.getContext(false).asInstanceOf[org.apache.logging.log4j.core.LoggerContext]
+    val config = ctx.getConfiguration.asInstanceOf[AbstractConfiguration]
+    val appender = config.getAppender(appenderName).asInstanceOf[FileAppender]
+    config.removeAppender(appenderName: String)
+    appender.stop()
+    ctx.updateLoggers()
   }
 
   // Some integration tests are for large Data, it needs long time to run.

--- a/src/it/scala/org/apache/spark/sql/SFDateFunctionsSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDateFunctionsSuite.scala
@@ -480,7 +480,7 @@ class SFDateFunctionsSuite extends SFQueryTest with SFTestSessionBase {
     checkAnswer(df.select(to_date(col("s"), "yyyy-hh-MM")), Seq(Row(null), Row(null), Row(null)))
     val e = intercept[SparkUpgradeException](df.select(to_date(col("s"), "yyyy-dd-aa")).collect())
     assert(e.getCause.isInstanceOf[IllegalArgumentException])
-    assert(e.getMessage.contains("You may get a different result due to the upgrading of Spark"))
+    assert(e.getMessage.contains("You may get a different result due to the upgrading to Spark"))
 
     // february
     val x1 = "2016-02-29"

--- a/src/it/scala/org/apache/spark/sql/snowflake/SFTestSessionBase.scala
+++ b/src/it/scala/org/apache/spark/sql/snowflake/SFTestSessionBase.scala
@@ -2,6 +2,7 @@ package org.apache.spark.sql.snowflake
 
 import net.snowflake.spark.snowflake.{IntegrationEnv, Parameters}
 import org.apache.spark.sql.SparkSession
+import org.apache.logging.log4j.Level
 
 import scala.language.implicitConversions
 import scala.util.Random
@@ -33,7 +34,11 @@ trait SFTestSessionBase extends IntegrationEnv {
   override def beforeAll(): Unit = {
     super.beforeAll()
     // Run ported test in WARN level to avoid large log volume
-    reconfigureLogFile(PORTED_TEST_LOG4J_PROPERTY)
+    if (USE_LOG4J2_PROPERTIES) {
+      reconfigureLog4j2LogLevel(Level.WARN)
+    } else {
+      reconfigureLogFile(PORTED_TEST_LOG4J_PROPERTY)
+    }
     // connectorOptionsTestTempSchema should have the temp schema replacing
     // sfSchema
     tempSchema = s"testTempSchema_${Math.abs(Random.nextLong()).toString}"
@@ -50,7 +55,11 @@ trait SFTestSessionBase extends IntegrationEnv {
   override def afterAll(): Unit = {
     try {
       // Reset test log level to default.
-      reconfigureLogFile(DEFAULT_LOG4J_PROPERTY)
+      if (USE_LOG4J2_PROPERTIES) {
+        reconfigureLog4j2LogLevel(Level.INFO)
+      } else {
+        reconfigureLogFile(DEFAULT_LOG4J_PROPERTY)
+      }
       if (_spark != null) {
         try {
           _spark.sessionState.catalog.reset()

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -34,7 +34,7 @@ object SnowflakeConnectorUtils {
     * Check Spark version, if Spark version matches SUPPORT_SPARK_VERSION enable PushDown,
     * otherwise disable it.
     */
-  val SUPPORT_SPARK_VERSION = "3.2"
+  val SUPPORT_SPARK_VERSION = "3.3"
 
   def checkVersionAndEnablePushdown(session: SparkSession): Boolean =
     if (session.version.startsWith(SUPPORT_SPARK_VERSION)) {

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -222,9 +222,9 @@ class MiscSuite01 extends FunSuite with Matchers {
     assert(sparkConfNode.get("spark.driver.memory").asText().equals("2G"))
     assert(sparkConfNode.get("spark.executor.memory").asText().equals("888M"))
     assert(sparkConfNode.get("spark.driver.extraJavaOptions")
-      .asText().equals("-Duser.timezone=GMT"))
+      .asText().contains("-Duser.timezone=GMT"))
     assert(sparkConfNode.get("spark.executor.extraJavaOptions")
-      .asText().equals("-Duser.timezone=UTC"))
+      .asText().contains("-Duser.timezone=UTC"))
     assert(sparkConfNode.get("spark.sql.session.timeZone").asText().equals("America/Los_Angeles"))
   }
 


### PR DESCRIPTION
For spark 3.3 support, the main change affects  Spark connector is that the Spark 3.3 migrating from `log4j 1` to `log4j 2`.

Spark Connector did below changes to use the new logging system in test
1. Add a default log4j2 configuration file to `src/it/resources/log4j2.properties` which is used by spark automatically.
2. The test cases in `src/it/scala/org/apache/spark/sql/` need to be run in `WARN` level otherwise, the Github action will fail because the test exceed the max time. 
    - With `log4j 1`, SC test reconfigure another log properties file with WARN.
    - With `log4j 2`, SC dynamically configure log level as WARN in beforeAll and configure it back to INFO in afterAll.
3. The test case `SecuritySuite.scala` needs to configure the output to a file (the default is console). 
    - With `log4j 1`, SC test reconfigure another log properties file with writing to a file.
    - With `log4j 2`, SC dynamically configure add a FileAppender to the logging system and drop the FileAppender after test done.

https://snowflakecomputing.atlassian.net/browse/SNOW-624169