### PR TITLE
SNOW-521177 Don't use new connection to check table existence when saving DF

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -166,6 +166,16 @@ object Parameters {
   val PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY: String = knownParam(
     "internal_check_table_existence_in_current_schema_only"
   )
+  // Internal option to check table existence with fully qualified name when writing
+  // a DataFrame to a snowflake table. Its' true by default. For example,
+  // 1. For table1, the fully qualified name is {sfDatabase}.{sfSchema}.table1
+  // 2. For schema1.table1, the fully qualified name is {sfDatabase}.schema1.table1
+  // NOTE: For writing a DataFrame to a snowflake table, if this option is true,
+  // "internal_check_table_existence_in_current_schema_only" is not used any more.
+  // This option may be removed without any notice in any time.
+  val PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_WITH_FULLY_QUALIFIED_NAME: String = knownParam(
+    "internal_check_table_existence_with_fully_qualified_name"
+  )
   // Internal option to skip write operation when writing a DataFrame
   // without any partitions. By default, it it is 'false'.
   // This option may be removed without any notice in any time.
@@ -663,6 +673,10 @@ object Parameters {
     def checkTableExistenceInCurrentSchemaOnly: Boolean = {
       isTrue(parameters.getOrElse(
         PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_IN_CURRENT_SCHEMA_ONLY, "true"))
+    }
+    def checkTableExistenceWithFullyQualifiedName: Boolean = {
+      isTrue(parameters.getOrElse(
+        PARAM_INTERNAL_CHECK_TABLE_EXISTENCE_WITH_FULLY_QUALIFIED_NAME, "true"))
     }
     def skipWriteWhenWritingEmptyDataFrame: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_SKIP_WRITE_WHEN_WRITING_EMPTY_DATAFRAME, "false"))

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -724,4 +724,64 @@ object Utils {
     }
     // scalastyle:off println
   }
+
+  // Find the first un-quoted char '.', return -1 if not found
+  private def findFirstUnquotedDotIndex(data: String): Int = {
+    var quoteCount = 0
+    for (i <- 0 until data.length) {
+      if (data(i) == '"') {
+        quoteCount = quoteCount + 1
+      } else if (data(i) == '.') {
+        if (quoteCount % 2 == 0) {
+          return i
+        }
+      }
+    }
+    -1
+  }
+
+  // Split object name with unquoted dot.
+  private[snowflake] def splitNameByDot(name: String): Seq[String] = {
+    val result = new mutable.ArrayBuffer[String]
+    var data = name
+    var done = false
+    while (!done) {
+      val dotIndex = findFirstUnquotedDotIndex(data)
+      if (dotIndex == -1) {
+        result.append(data)
+        done = true
+      } else {
+        result.append(data.substring(0, dotIndex))
+        data = data.substring(dotIndex + 1)
+      }
+    }
+    result.toSeq
+  }
+
+  // Adjust table name by adding database or schema name for table existence check.
+  private[snowflake] def getTableNameForExistenceCheck(database: String,
+                                                       schema: String,
+                                                       name: String): String = {
+    val unQuotedIdPattern = """([a-zA-Z_][\w$]*)"""
+    val quotedIdPattern = """("([^"]|"")+")"""
+    val idPattern = s"($unQuotedIdPattern|$quotedIdPattern)"
+
+    val nameParts = splitNameByDot(name)
+    //     identifier
+    //     identifier.identifier
+    //     identifier.identifier.identifier
+    //     identifier..identifier // It's equals to identifier.PUBLIC.identifier
+    if (nameParts.length == 1 && name.matches(idPattern)) {
+      // Add database and schema name
+      s"${ensureQuoted(database)}.${ensureQuoted(schema)}.$name"
+    } else if (nameParts.length == 2 && nameParts.head.matches(idPattern)
+      && nameParts.last.matches(idPattern)) {
+      // Add database name
+      s"${ensureQuoted(database)}.$name"
+    } else {
+      // For all the other cases, don't adjust it
+      name
+    }
+  }
+
 }

--- a/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
@@ -127,4 +127,46 @@ class UtilsSuite extends FunSuite with Matchers {
     assert(Utils.getLastPutCommand == null)
     assert(Utils.getLastGetCommand == null)
   }
+
+  test("Utils.getTableNameForExistenceCheck") {
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "t1")
+      .equals(""""DB"."SCHEMA".t1"""))
+    assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"t1\"")
+      .equals(""""db.1"."schema!1"."t1""""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "s1.t1")
+      .equals(""""DB".s1.t1"""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "d1.s1.t1")
+      .equals("""d1.s1.t1"""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "d1..t1")
+      .equals("""d1..t1"""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"s1\".t1")
+      .equals(""""DB"."s1".t1"""))
+    // Db and schema has special character
+    assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"s1\".\"t1\"")
+      .equals(""""db.1"."s1"."t1""""))
+    assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"d1\".\"s1\".\"t1\"")
+      .equals(""""d1"."s1"."t1""""))
+    assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"d1\"..\"t1\"")
+      .equals(""""d1".."t1""""))
+
+    // If the name is invalid, just get the original name.
+    val invalidNames = Seq(".t1", "t1.", ".", "..", "...", ".s1.t1", ".d1.s1.t1", "d1.s1.t1.", "d1...t1")
+    invalidNames.foreach { s =>
+      assert(Utils.getTableNameForExistenceCheck("sfDb", "sfSchema", s).equals(s))
+    }
+  }
+
+  test("test Utils.splitNameByDot") {
+    assert(Utils.splitNameByDot("a.b.c") sameElements Seq("a", "b", "c"))
+    assert(Utils.splitNameByDot("""a.b".".c""") sameElements Seq("a", """b"."""", "c"))
+
+    assert(Utils.splitNameByDot("""a..c""") sameElements Seq("a", "", "c"))
+    assert(Utils.splitNameByDot(""".b.c""") sameElements Seq("", "b", "c"))
+    assert(Utils.splitNameByDot("""a.b.""") sameElements Seq("a", "b", ""))
+    assert(Utils.splitNameByDot(""".b.""") sameElements Seq("", "b", ""))
+    assert(Utils.splitNameByDot("""."".""") sameElements Seq("", """""""", ""))
+    assert(Utils.splitNameByDot("..") sameElements Seq("", "", ""))
+    assert(Utils.splitNameByDot(".") sameElements Seq("", ""))
+    assert(Utils.splitNameByDot("") sameElements Seq(""))
+  }
 }

--- a/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/UtilsSuite.scala
@@ -131,8 +131,6 @@ class UtilsSuite extends FunSuite with Matchers {
   test("Utils.getTableNameForExistenceCheck") {
     assert(Utils.getTableNameForExistenceCheck("db", "schema", "t1")
       .equals(""""DB"."SCHEMA".t1"""))
-    assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"t1\"")
-      .equals(""""db.1"."schema!1"."t1""""))
     assert(Utils.getTableNameForExistenceCheck("db", "schema", "s1.t1")
       .equals(""""DB".s1.t1"""))
     assert(Utils.getTableNameForExistenceCheck("db", "schema", "d1.s1.t1")
@@ -141,7 +139,10 @@ class UtilsSuite extends FunSuite with Matchers {
       .equals("""d1..t1"""))
     assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"s1\".t1")
       .equals(""""DB"."s1".t1"""))
+
     // Db and schema has special character
+    assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"t1\"")
+      .equals(""""db.1"."schema!1"."t1""""))
     assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"s1\".\"t1\"")
       .equals(""""db.1"."s1"."t1""""))
     assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"d1\".\"s1\".\"t1\"")
@@ -149,24 +150,32 @@ class UtilsSuite extends FunSuite with Matchers {
     assert(Utils.getTableNameForExistenceCheck("db.1", "schema!1", "\"d1\"..\"t1\"")
       .equals(""""d1".."t1""""))
 
+    // Table name or schema name have quoted dot.
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"table1.\"")
+      .equals(""""DB"."SCHEMA"."table1.""""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"table.1\"")
+      .equals(""""DB"."SCHEMA"."table.1""""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\".table1\"")
+      .equals(""""DB"."SCHEMA".".table1""""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"sc1.\".\"table1.\"")
+      .equals(""""DB"."sc1."."table1.""""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"sc.1\".\"table1.\"")
+      .equals(""""DB"."sc.1"."table1.""""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\".sc1\".\"table1.\"")
+      .equals(""""DB".".sc1"."table1.""""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"d1.\".\"sc1.\".\"table1.\"")
+      .equals("\"d1.\".\"sc1.\".\"table1.\""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\"d.1\".\"sc.1\".\"table1.\"")
+      .equals("\"d.1\".\"sc.1\".\"table1.\""))
+    assert(Utils.getTableNameForExistenceCheck("db", "schema", "\".d1\".\".sc1\".\"table1.\"")
+      .equals("\".d1\".\".sc1\".\"table1.\""))
+
     // If the name is invalid, just get the original name.
-    val invalidNames = Seq(".t1", "t1.", ".", "..", "...", ".s1.t1", ".d1.s1.t1", "d1.s1.t1.", "d1...t1")
+    val invalidNames =
+      Seq(".t1", "t1.", ".", "..", "...", ".s1.t1", ".d1.s1.t1", "d1.s1.t1.", "d1...t1")
     invalidNames.foreach { s =>
       assert(Utils.getTableNameForExistenceCheck("sfDb", "sfSchema", s).equals(s))
     }
   }
 
-  test("test Utils.splitNameByDot") {
-    assert(Utils.splitNameByDot("a.b.c") sameElements Seq("a", "b", "c"))
-    assert(Utils.splitNameByDot("""a.b".".c""") sameElements Seq("a", """b"."""", "c"))
-
-    assert(Utils.splitNameByDot("""a..c""") sameElements Seq("a", "", "c"))
-    assert(Utils.splitNameByDot(""".b.c""") sameElements Seq("", "b", "c"))
-    assert(Utils.splitNameByDot("""a.b.""") sameElements Seq("a", "b", ""))
-    assert(Utils.splitNameByDot(""".b.""") sameElements Seq("", "b", ""))
-    assert(Utils.splitNameByDot("""."".""") sameElements Seq("", """""""", ""))
-    assert(Utils.splitNameByDot("..") sameElements Seq("", "", ""))
-    assert(Utils.splitNameByDot(".") sameElements Seq("", ""))
-    assert(Utils.splitNameByDot("") sameElements Seq(""))
-  }
 }


### PR DESCRIPTION
SNOW-521177 Don't use new connection to check table existence when saving DF

Issue description
=============
The customer uses OAuth authentication to connect to snowflake and the token will expire soon after creating the connection. When writing a DataFrame to a table, SC uses a new connection to check the target table existence. The issue is that the token has expired when SC creates the new connection.


Reason to introduce the extra connection
===============================
The extra connection for table existence check is to resolve below case.
1. Suppose user sets `sfSchema = schema1` and will write DF to table `t1`.
2. `t1` doesn't exist in `schema1`, but it exists in schema `public`. The table existence check will return `true` because  unqualified object names are resolved through a search path and by default, the search path is `schema1, public`. For details refer to https://docs.snowflake.com/en/sql-reference/name-resolution.html#queries .
3. To resolve this issue, SC creates a new connection and executes `"alter session set search_path='$current'"` to make it only search in current schema.
4. The reason to introduce a new connection is to avoid the `alter session` command affect other following queries such as `postAction`.

Reference:
The PR to introduce extra connection: https://github.com/snowflakedb/spark-snowflake/pull/327
The Jira for the issue: https://snowflakecomputing.atlassian.net/browse/SNOW-262080

This fix proposal
=============
In this new proposal, we don't introduce new connection, and check the table existence with fully qualified name in current connection.
1. If the target table name is fully qualified name, just use it.
2. If it is <schema_name>.<table_name>, SC will add sfDataBase to it. e.g. <sfDatabase>. <schema_name>.<table_name>
3. If it is <table_name>, SC will add sfDatabase and sfSchema, e.g.  <sfDatabase>. <sfSchema>.<table_name>

NOTE:
1. This change is protected by an internal parameter
2. sfDatabase and sfSchema are Obligatory options.
3. We choose to use sfDatabase and sfSchema instead of executing a query to get currentDatabase and currentSchema because it is not necessary. The only possibility of current schema/database to be different with sfSchema/sfDatabase is that they executes `use database/schema` in preActions. This sounds like not a right way to use SC. If they do needs to write a table in different schema, they should use schema name in the target table.