### PR TITLE
SNOW-635353 Don't use parse_json() for COPY INTO with JSON file.

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -193,6 +193,14 @@ object Parameters {
     "internal_execute_query_in_sync_mode"
   )
 
+  // Internal option to use parse_json($1) when writing a DataFrame with complex types:
+  // StructType, ArrayType, MapType. By default, it is 'false'.
+  // This option may be removed without any notice in any time.
+  // Introduced since Spark Connector 2.10.1
+  val PARAM_INTERNAL_USE_PARSE_JSON_FOR_WRITE: String = knownParam(
+    "internal_use_parse_json_for_write"
+  )
+
   // Internal option to use AWS region URL. By default, it is 'true'.
   // This option may be removed without any notice in any time.
   // Introduced since Spark Connector 2.9.3
@@ -683,6 +691,9 @@ object Parameters {
     }
     def isExecuteQueryWithSyncMode: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_EXECUTE_QUERY_IN_SYNC_MODE, "false"))
+    }
+    def useParseJsonForWrite: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_PARSE_JSON_FOR_WRITE, "false"))
     }
     def getQueryIDUrl(queryID: String): String = {
       val patternWithPort = "(.*)(.snowflakecomputing.com)(:\\d*)(.*)".r

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -825,9 +825,10 @@ private[io] object StageWriter {
     ): SnowflakeSQLStatement =
       format match {
         case SupportedFormat.JSON =>
+          val columnPrefix = if (params.useParseJsonForWrite) "parse_json($1):" else "$1:"
           if (list.isEmpty || list.get.isEmpty) {
             val names = schema.fields
-              .map(x => "parse_json($1):".concat(
+              .map(x => columnPrefix.concat(
                 if (params.quoteJsonFieldName) {
                   "\"" + x.name + "\""
                 } else {
@@ -839,7 +840,7 @@ private[io] object StageWriter {
           } else {
             ConstantString("from (select") +
               list.get
-                .map(x => "parse_json($1):".concat(
+                .map(x => columnPrefix.concat(
                   if (params.quoteJsonFieldName) {
                     "\"" + schema(x._1 - 1).name + "\""
                   } else {

--- a/src/main/scala/net/snowflake/spark/snowflake/streaming/package.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/streaming/package.scala
@@ -121,17 +121,18 @@ package object streaming {
                              from: String): String =
       format match {
         case SupportedFormat.JSON =>
+          val columnPrefix = if (param.useParseJsonForWrite) "parse_json($1):" else "$1:"
           if (list.isEmpty || list.get.isEmpty) {
             val names =
               tableSchema.fields
                 .map(
                   x =>
-                    "parse_json($1):".concat(Utils.quotedNameIgnoreCase(x.name))
+                    columnPrefix.concat(Utils.quotedNameIgnoreCase(x.name))
                 )
                 .mkString(",")
             s"from (select $names $from tmp)"
           } else {
-            s"from (select ${list.get.map(x => "parse_json($1):".concat(
+            s"from (select ${list.get.map(x => columnPrefix.concat(
               Utils.quotedNameIgnoreCase(x._2))).mkString(", ")} $from tmp)"
           }
         case SupportedFormat.CSV =>


### PR DESCRIPTION

SNOW-635353 Don't use parse_json() for COPY INTO with JSON file.

When writing DF with complex type to a snowflake table, the COPY INTO TABLE command
generated by Spark Connector uses "parse_json($1):<column_name>".
This is inefficient. Spark Connector should use "$1:<column_name>".