### PR TITLE
SNOW-638510 Add some fields to SPARK_CLIENT_INFO

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
@@ -11,8 +11,10 @@ import org.apache.spark.sql.types._
 import scala.collection.mutable
 import scala.util.Random
 
-private[snowflake] class FakeTelemetryMessageSender(buffer: mutable.ArrayBuffer[ObjectNode])
+private[snowflake] class MockTelemetryMessageSender(buffer: mutable.ArrayBuffer[ObjectNode])
   extends TelemetryMessageSender {
+  // the telemetry messages are appended into the buffer instead of sending to snowflake,
+  // So that the test case can check the message to be sent.
   override def send(telemetry: Telemetry, logs: List[(ObjectNode, Long)]): Unit = {
     logs.foreach {
       case (log, _) => buffer.append(log)
@@ -55,7 +57,7 @@ class SnowflakeTelemetrySuite extends IntegrationSuiteBase {
     // Enable dummy sending telemetry message.
     val messageBuffer = mutable.ArrayBuffer[ObjectNode]()
     val oldSender = SnowflakeTelemetry.setTelemetryMessageSenderForTest(
-      new FakeTelemetryMessageSender(messageBuffer))
+      new MockTelemetryMessageSender(messageBuffer))
     try {
       // A basis dataframe read
       val df1 = sparkSession.read

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
@@ -38,7 +38,7 @@ class SnowflakeTelemetrySuite extends IntegrationSuiteBase {
     assert(SnowflakeTelemetry.detectSparkLanguage(sparkConf).equals("Scala"))
     // Manually set pyspark
     sparkConf.set("spark.pyspark.python", "/usr/bin/python3")
-    assert(SnowflakeTelemetry.detectSparkLanguage(sparkConf).equals("python3"))
+    assert(SnowflakeTelemetry.detectSparkLanguage(sparkConf).equals("Python"))
     // Manually set R language
     sparkConf.set("spark.r.command", "R")
     assert(SnowflakeTelemetry.detectSparkLanguage(sparkConf).equals("R"))

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
@@ -1,0 +1,86 @@
+package net.snowflake.spark.snowflake
+
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode
+import net.snowflake.spark.snowflake.SnowflakeTelemetry.mapper
+import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.types._
+
+import scala.collection.mutable
+import scala.util.Random
+
+class SnowflakeTelemetrySuite extends IntegrationSuiteBase {
+
+  private val test_table: String = s"test_table_1_$randomSuffix"
+  private val test_table2: String = s"test_table_2_$randomSuffix"
+
+  private val mapper = new ObjectMapper
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    SnowflakeConnectorUtils.enablePushdownSession(sparkSession)
+  }
+
+  test("unit test: SnowflakeTelemetry.detectSparkLanguage") {
+    val sparkConf = SparkEnv.get.conf.clone()
+    assert(SnowflakeTelemetry.detectSparkLanguage(sparkConf).equals("Scala"))
+    // Manually set pyspark
+    sparkConf.set("spark.pyspark.python", "/usr/bin/python3")
+    assert(SnowflakeTelemetry.detectSparkLanguage(sparkConf).equals("python3"))
+    // Manually set R language
+    sparkConf.set("spark.r.command", "R")
+    assert(SnowflakeTelemetry.detectSparkLanguage(sparkConf).equals("R"))
+  }
+
+  test("unit test: SnowflakeTelemetry.addCommonFields") {
+    val metric: ObjectNode = mapper.createObjectNode()
+    SnowflakeTelemetry.addCommonFields(metric)
+    assert(metric.size() == 1 &&
+      metric.get(TelemetryFieldNames.SPARK_APPLICATION_ID).asText().startsWith("local-"))
+  }
+
+  test("IT test: common fields are added") {
+    try {
+      // Enable dummy sending telemetry message.
+      val fakeMessageSender = mutable.ArrayBuffer[ObjectNode]()
+      SnowflakeTelemetry.setFakeMessageSender(fakeMessageSender)
+
+      // A basis dataframe read
+      val df1 = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("query", "select current_timestamp()")
+        .load()
+      df1.collect()
+
+      fakeMessageSender.foreach { x =>
+        val typeName = x.get("type").asText()
+        val source = x.get("source").asText()
+        assert(source.equals("spark_connector"))
+        val data = x.get("data")
+        assert(data.get(TelemetryFieldNames.SPARK_APPLICATION_ID).asText().startsWith("local-"))
+        if (typeName.equals("spark_client_info")) {
+          // Spark language is added for spark_client_info
+          assert(data.get(TelemetryFieldNames.SPARK_LANGUAGE).asText().equals("Scala"))
+        }
+      }
+    } finally {
+      // Reset to send telemetry normally
+      SnowflakeTelemetry.setFakeMessageSender(null)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      jdbcUpdate(s"drop table if exists $test_table")
+      jdbcUpdate(s"drop table if exists $test_table2")
+    } finally {
+      super.afterAll()
+      SnowflakeConnectorUtils.disablePushdownSession(sparkSession)
+    }
+  }
+
+}

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
@@ -33,10 +33,10 @@ object SnowflakeTelemetry {
 
   private[snowflake] var output: ObjectNode = _
 
-  private var telemetryMessageSender: TelemetryMessageSender = new RealTelemetryMessageSender
+  private var telemetryMessageSender: TelemetryMessageSender = new SnowflakeTelemetryMessageSender
 
-  private[snowflake]
-  def setTelemetryMessageSenderForTest(sender: TelemetryMessageSender): TelemetryMessageSender = {
+  private[snowflake] def setTelemetryMessageSenderForTest(sender: TelemetryMessageSender)
+  : TelemetryMessageSender = {
     val oldSender = telemetryMessageSender
     telemetryMessageSender = sender
     oldSender
@@ -385,7 +385,7 @@ object SnowflakeTelemetry {
       || sparkConf.contains("spark.r.shell.command")) {
       "R"
     } else if (sparkConf.contains("spark.pyspark.python")) {
-      sparkConf.get("spark.pyspark.python").split("/").last
+      "Python"
     } else {
       "Scala"
     }
@@ -584,7 +584,7 @@ private[snowflake] trait TelemetryMessageSender {
   def send(telemetry: Telemetry, logs: List[(ObjectNode, Long)]): Unit
 }
 
-private final class RealTelemetryMessageSender extends TelemetryMessageSender {
+private final class SnowflakeTelemetryMessageSender extends TelemetryMessageSender {
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def send(telemetry: Telemetry, logs: List[(ObjectNode, Long)]): Unit = {

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
@@ -172,6 +172,7 @@ private[snowflake] object StageReader {
   private[snowflake] def sendEgressUsage(bytes: Long, conn: Connection): Unit = {
     val metric: ObjectNode = mapper.createObjectNode()
     metric.put(OUTPUT_BYTES, bytes)
+    SnowflakeTelemetry.addCommonFields(metric)
 
     SnowflakeTelemetry.addLog(
       (TelemetryTypes.SPARK_EGRESS, metric),

--- a/src/main/scala/net/snowflake/spark/snowflake/streaming/SnowflakeSink.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/streaming/SnowflakeSink.scala
@@ -125,6 +125,7 @@ class SnowflakeSink(sqlContext: SQLContext,
         val time = System.currentTimeMillis()
         metric.put(END_TIME, time)
         metric.get(LOAD_RATE).asInstanceOf[ObjectNode].put(END_TIME, time)
+        SnowflakeTelemetry.addCommonFields(metric)
 
         SnowflakeTelemetry.addLog(
           ((TelemetryTypes.SPARK_STREAMING, metric), time)
@@ -172,6 +173,7 @@ class SnowflakeSink(sqlContext: SQLContext,
 
       if (time - lastMetricSendTime > telemetrySendTime) {
         rate.put(END_TIME, time)
+        SnowflakeTelemetry.addCommonFields(rate)
         SnowflakeTelemetry.addLog(
           ((TelemetryTypes.SPARK_STREAMING, metric.deepCopy()), time)
         )
@@ -210,6 +212,7 @@ class SnowflakeSink(sqlContext: SQLContext,
       (sqlContext.sparkSession.sparkContext.appName + streamingStartTime.toString).hashCode
     )
     message.put(START_TIME, streamingStartTime)
+    SnowflakeTelemetry.addCommonFields(message)
 
     SnowflakeTelemetry.addLog(
       (TelemetryTypes.SPARK_STREAMING_START, message),
@@ -230,6 +233,7 @@ class SnowflakeSink(sqlContext: SQLContext,
     )
     message.put(START_TIME, streamingStartTime)
     message.put(END_TIME, endTime)
+    SnowflakeTelemetry.addCommonFields(message)
 
     SnowflakeTelemetry.addLog(
       (TelemetryTypes.SPARK_STREAMING_END, message),


### PR DESCRIPTION
These PR added 3 items:
1. Add language name to SPARK_CLIENT_INFO
2. Add spark configuration names if they are not in the white-list. ("N/A" is set in the message for the value)
3. Add SPARK_APPLICATION_ID to all telemetry messages.
4. Introduce `TelemetryMessageSender` for testing purpose.