### PR TITLE
SNOW-639416 Add new telemetry message SPARK_INGRESS and add update SPARK_EGRESS

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -479,7 +479,8 @@ object CloudStorageOperations {
 }
 
 class FileUploadResult(val fileName: String,
-                       val fileSize: Long) extends Serializable {
+                       val fileSize: Long,
+                       val rowCount: Long) extends Serializable {
 }
 
 private[io] class SingleElementIterator(fileUploadResult: FileUploadResult)
@@ -759,7 +760,7 @@ sealed trait CloudStorage {
          | $processTimeInfo
          |""".stripMargin.filter(_ >= ' '))
 
-    new SingleElementIterator(new FileUploadResult(s"$directory/$fileName", dataSize))
+    new SingleElementIterator(new FileUploadResult(s"$directory/$fileName", dataSize, rowCount))
   }
 
   protected def uploadRDD(data: RDD[String],

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
@@ -19,7 +19,6 @@ private[snowflake] object StageReader {
 
   private val mapper: ObjectMapper = new ObjectMapper()
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  private val OUTPUT_BYTES = TelemetryFieldNames.OUTPUT_BYTES
 
   def readFromStage(sqlContext: SQLContext,
                     params: MergedParameters,
@@ -81,6 +80,7 @@ private[snowflake] object StageReader {
 
     // Verify it's the expected format
     val sch = res.getMetaData
+    val queryID = res.asInstanceOf[SnowflakeResultSet].getQueryID
     if (sch.getColumnCount >= 3) {
       // Format V1 for COPY INTO LOCATION. The result format is:
       // rows_unloaded    input_bytes    output_bytes
@@ -92,11 +92,13 @@ private[snowflake] object StageReader {
         || "FILE_SIZE".equalsIgnoreCase(thirdColumnName))
         && "number".equalsIgnoreCase(thirdColumnType))
       {
+        var rowCount: Long = 0
         var dataSize: Long = 0
         while (res.next) {
+          rowCount += res.getLong(1)
           dataSize += res.getLong(3)
         }
-        sendEgressUsage(dataSize, conn)
+        sendEgressUsage(conn, queryID, rowCount, dataSize)
       } else {
         logger.warn(
           s"""The result format of COPY INTO LOCATION is not recognized.
@@ -169,9 +171,14 @@ private[snowflake] object StageReader {
 
   }
 
-  private[snowflake] def sendEgressUsage(bytes: Long, conn: Connection): Unit = {
+  private[snowflake] def sendEgressUsage(conn: Connection,
+                                         queryId: String,
+                                         rowCount: Long,
+                                         bytes: Long): Unit = {
     val metric: ObjectNode = mapper.createObjectNode()
-    metric.put(OUTPUT_BYTES, bytes)
+    metric.put(TelemetryFieldNames.OUTPUT_BYTES, bytes)
+    metric.put(TelemetryFieldNames.ROW_COUNT, rowCount)
+    metric.put(TelemetryFieldNames.QUERY_ID, queryId)
     SnowflakeTelemetry.addCommonFields(metric)
 
     SnowflakeTelemetry.addLog(
@@ -179,6 +186,6 @@ private[snowflake] object StageReader {
       System.currentTimeMillis()
     )
     SnowflakeTelemetry.send(conn.getTelemetry)
-    logger.debug(s"Data Egress Usage: $bytes bytes".stripMargin)
+    logger.debug(s"Data Egress Usage: $bytes bytes, $rowCount rows".stripMargin)
   }
 }


### PR DESCRIPTION
SNOW-639416 Add new telemetry message SPARK_INGRESS and add some fields to SPARK_EGRESS

1. The new telemetry message `SPARK_INGRESS` is used to track the data volume written to snowflake. It includes 4 fields: QUERY_ID, DATA_SIZE, ROW_COUNT, APPLICATION_ID

2. Add 3 fields to SPARK_EGRESS which included the DATA_SIZE to read from Snowflake. The 3 new fields are QUERY_ID, ROW_COUNT and APPLICATION_ID to align with SPARK_INGRESS