### PR TITLE
SNOW-639519 Add spark libraries to SPARK_CLIENT_INFO

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
@@ -70,13 +70,24 @@ object SnowflakeTelemetry {
           .map(_.getClassName)
           .map(_.replaceAll("\\$", "")) // Replace $ for Scala object class
 
+        val userApplicationPackage = if (classNames.head.contains(".")) {
+          classNames.head.split("\\.").dropRight(1).mkString("", ".", ".")
+        } else {
+          classNames.head
+        }
         // Skip known libraries and user's application package
-        val knownLibraries = Seq("java.", "scala.", "net.snowflake.spark.snowflake.") ++
-          Seq(classNames.head.split("\\.").dropRight(1).mkString("", ".", "."))
+        val knownLibraries =
+          Seq("java.", "scala.", "net.snowflake.spark.snowflake.", userApplicationPackage)
 
         val result = classNames
           .filterNot(name => knownLibraries.exists(name.startsWith)) // Remove known libraries
-          .map(_.split("\\.").dropRight(1).mkString(".")) // Remove class name to get package names
+          .map { name => // Get package names
+            if (name.contains(".")) {
+              name.split("\\.").dropRight(1).mkString(".")
+            } else {
+              name
+            }
+          }
           .distinct
 
         // Cache the spark libraries result


### PR DESCRIPTION
SNOW-639519 Add spark libraries to SPARK_CLIENT_INFO

The sample message for spark-submit
---------------------
```
22/08/04 11:44:14 INFO SparkConnectorContext$: Spark Connector system config: {
  "spark_connector_version" : "2.10.0",
  "spark_version" : "3.2.2",
  "application_name" : "Spark SQL basic example",
  "scala_version" : "2.12.15",
  "java_version" : "11.0.12",
  "jdbc_version" : "3.13.14",
  "certified_jdbc_version" : "3.13.14",
  "os_name" : "Mac OS X",
  "max_memory_in_mb" : 1024,
  "total_memory_in_mb" : 1024,
  "free_memory_in_mb" : 828,
  "cpu_cores" : 16,
  "spark_application_id" : "local-1659638652697",
  "spark_language" : "Scala",
  "is_pyspark" : false,
  "spark_config" : {
    "spark.master" : "local",
    "spark.app.startTime" : "N/A",
    "spark.some.config.option" : "N/A",
    "spark.sql.warehouse.dir" : "N/A",
    "spark.driver.host" : "172.16.196.81",
    "spark.executor.id" : "driver",
    "spark.app.initial.jar.urls" : "N/A",
    "spark.jars" : "file:///Users/mrui/Snowflake/spark-snowflake/target/scala-2.12/spark-snowflake_2.12-2.10.0-spark_3.2.jar,file:///Users/mrui/.m2/repository/net/snowflake/snowflake-jdbc/3.13.14/snowflake-jdbc-3.13.14.jar,file:/Users/mrui/Snowflake/spark-snowflake/ClusterTest/target/scala-2.12/clustertest_2.12-1.0.jar",
    "spark.repl.local.jars" : "file:///Users/mrui/Snowflake/spark-snowflake/target/scala-2.12/spark-snowflake_2.12-2.10.0-spark_3.2.jar,file:///Users/mrui/.m2/repository/net/snowflake/snowflake-jdbc/3.13.14/snowflake-jdbc-3.13.14.jar",
    "spark.app.id" : "local-1659638652697",
    "spark.driver.port" : "N/A",
    "spark.submit.pyFiles" : "N/A",
    "spark.submit.deployMode" : "client",
    "spark.app.name" : "Spark SQL basic example"
  },
  "libraries" : [ "jdk.internal.reflect", "org.apache.spark.sql", "org.apache.spark.sql.execution.datasources" ]
}
```

The sample message for pyspark
---------------------------------
```
22/08/04 11:37:29 INFO SparkConnectorContext$: Spark Connector system config: {
  "spark_connector_version" : "2.10.0",
  "spark_version" : "3.2.2",
  "application_name" : "PythonClusterTest",
  "scala_version" : "2.12.15",
  "java_version" : "11.0.12",
  "jdbc_version" : "3.13.14",
  "certified_jdbc_version" : "3.13.14",
  "os_name" : "Mac OS X",
  "max_memory_in_mb" : 1024,
  "total_memory_in_mb" : 1024,
  "free_memory_in_mb" : 922,
  "cpu_cores" : 16,
  "spark_application_id" : "local-1659638247152",
  "spark_language" : "Python",
  "is_pyspark" : true,
  "spark_config" : {
    "spark.master" : "local",
    "spark.driver.port" : "N/A",
    "spark.app.name" : "PythonClusterTest",
    "spark.pyspark.driver.python" : "python3",
    "spark.app.id" : "local-1659638247152",
    "spark.sql.warehouse.dir" : "N/A",
    "spark.driver.host" : "172.16.196.81",
    "spark.executor.id" : "driver",
    "spark.app.initial.jar.urls" : "N/A",
    "spark.jars" : "file:///Users/mrui/Snowflake/spark-snowflake/target/scala-2.12/spark-snowflake_2.12-2.10.0-spark_3.2.jar,file:///Users/mrui/.m2/repository/net/snowflake/snowflake-jdbc/3.13.14/snowflake-jdbc-3.13.14.jar",
    "spark.rdd.compress" : "N/A",
    "spark.repl.local.jars" : "file:///Users/mrui/Snowflake/spark-snowflake/target/scala-2.12/spark-snowflake_2.12-2.10.0-spark_3.2.jar,file:///Users/mrui/.m2/repository/net/snowflake/snowflake-jdbc/3.13.14/snowflake-jdbc-3.13.14.jar",
    "spark.serializer.objectStreamReset" : "N/A",
    "spark.app.startTime" : "N/A",
    "spark.submit.pyFiles" : "N/A",
    "spark.submit.deployMode" : "client",
    "spark.pyspark.python" : "python3"
  },
  "libraries" : [ "py4j", "py4j.commands", "py4j.reflection", "jdk.internal.reflect", "org.apache.spark.sql", "org.apache.spark.sql.execution.datasources" ]
}
```