### PR TITLE
SNOW-648611 Update versions

### DIFF
--- a/.github/workflows/ClusterTest.yml
+++ b/.github/workflows/ClusterTest.yml
@@ -22,8 +22,8 @@ jobs:
         DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.3.0'
         TEST_SCALA_VERSION: '2.12'
         TEST_COMPILE_SCALA_VERSION: '2.12.11'
-        TEST_SPARK_CONNECTOR_VERSION: '2.10.1'
-        TEST_JDBC_VERSION: '3.13.14'
+        TEST_SPARK_CONNECTOR_VERSION: '2.11.0'
+        TEST_JDBC_VERSION: '3.13.22'
 
     steps:
     - uses: actions/checkout@v2

--- a/ClusterTest/build.sbt
+++ b/ClusterTest/build.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-val sparkConnectorVersion = "2.10.1"
+val sparkConnectorVersion = "2.11.0"
 val scalaVersionMajor = "2.12"
 val sparkVersionMajor = "3.3"
 val sparkVersion = s"${sparkVersionMajor}.0"
@@ -36,8 +36,8 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
     resolvers +=
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
-      "net.snowflake" % "snowflake-ingest-sdk" % "0.10.3",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.14",
+      "net.snowflake" % "snowflake-ingest-sdk" % "0.10.8",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.22",
       // "net.snowflake" %% "spark-snowflake" % "2.8.0-spark_3.0",
       // "com.google.guava" % "guava" % "14.0.1" % Test,
       // "org.scalatest" %% "scalatest" % "3.0.5" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.3.0")
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.10.1"
+val sparkConnectorVersion = "2.11.0"
 
 lazy val ItTest = config("it") extend Test
 
@@ -51,13 +51,13 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
     resolvers +=
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
-      "net.snowflake" % "snowflake-ingest-sdk" % "0.10.3",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.14",
+      "net.snowflake" % "snowflake-ingest-sdk" % "0.10.8",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.22",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test,
       "org.mockito" % "mockito-core" % "1.10.19" % Test,
       "org.apache.commons" % "commons-lang3" % "3.5" % "provided",
       // For test to read/write from postgresql
-      "org.postgresql" % "postgresql" % "42.3.6" % Test,
+      "org.postgresql" % "postgresql" % "42.4.1" % Test,
       // Below is for Spark Streaming from Kafka test only
       // "org.apache.spark" %% "spark-sql-kafka-0-10" % "2.4.0",
       "org.apache.spark" %% "spark-core" % testSparkVersion % "provided, test",

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -55,12 +55,12 @@ object Utils {
     */
   val SNOWFLAKE_SOURCE_SHORT_NAME = "snowflake"
 
-  val VERSION = "2.10.1"
+  val VERSION = "2.11.0"
 
   /**
     * The certified JDBC version to work with this spark connector version.
     */
-  val CERTIFIED_JDBC_VERSION = "3.13.14"
+  val CERTIFIED_JDBC_VERSION = "3.13.22"
 
   /**
     * Important:


### PR DESCRIPTION
1. Update spark connector version as 2.11.0
2. Update JDBC version to 3.13.22
3. Update snowflake-ingest-sdk to 0.10.8
4. Update test dependency: PostgreSQL JDBC Driver to 42.4.1 to avoid vulnerabilities: CVE-2022-31197