### PR TITLE
SNOW-608021 Support S3 VPCE deployment

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
@@ -17,7 +17,7 @@
 package net.snowflake.spark.snowflake.io
 
 import java.io.File
-import net.snowflake.client.jdbc.SnowflakeFileTransferMetadataV1
+import net.snowflake.client.jdbc.{SnowflakeFileTransferMetadataV1, SnowflakeSQLException}
 import net.snowflake.client.jdbc.internal.apache.commons.io.FileUtils
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}
@@ -378,7 +378,8 @@ class StageSuite extends IntegrationSuiteBase {
         pref = "test_dir",
         connection = connection,
         useRegionUrl = None,
-        regionName = None
+        regionName = None,
+        stageEndPoint = None
       )
 
       assertThrows[Exception]({
@@ -497,7 +498,8 @@ class StageSuite extends IntegrationSuiteBase {
         pref = "test_dir",
         connection = connection,
         useRegionUrl = None,
-        regionName = None
+        regionName = None,
+        stageEndPoint = None
       )
 
       val storageInfo: Map[String, String] = Map()
@@ -617,6 +619,18 @@ class StageSuite extends IntegrationSuiteBase {
       )
       TestHook.disableTestHook()
     }
+  }
+
+  test("negative test Parameters.PARAM_S3_STAGE_VPCE_DNS_NAME") {
+    val ex = intercept[SnowflakeSQLException] {
+      sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option(Parameters.PARAM_S3_STAGE_VPCE_DNS_NAME, "negative_test_invalid_s3_dns")
+        .option("query", "select 'any-query'")
+        .load()
+    }
+    assert(ex.getMessage.contains("invalid value [negative_test_invalid_s3_dns] for parameter"))
   }
 }
 // scalastyle:on println

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -208,6 +208,16 @@ object Parameters {
     "internal_use_aws_region_url"
   )
 
+  // Session level parameter S3_STAGE_VPCE_DNS_NAME
+  val PARAM_S3_STAGE_VPCE_DNS_NAME: String = knownParam("s3_stage_vpce_dns_name")
+
+  // Internal option to support AWS stage endPoint. This may be used for AWS S3 FIPS and VPCE.
+  // by default, it is 'true'. This option may be removed without any notice in any time.
+  // Introduced since Spark Connector 2.11.1
+  val PARAM_INTERNAL_SUPPORT_AWS_STAGE_END_POINT: String = knownParam(
+    "internal_support_aws_stage_end_point"
+  )
+
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
 
@@ -671,6 +681,12 @@ object Parameters {
     }
     def useAWSRegionURL: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_USE_AWS_REGION_URL, "true"))
+    }
+    def getS3StageVpceDnsName: Option[String] = {
+      parameters.get(PARAM_S3_STAGE_VPCE_DNS_NAME)
+    }
+    def supportAWSStageEndPoint: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_INTERNAL_SUPPORT_AWS_STAGE_END_POINT, "true"))
     }
     def stagingTableNameRemoveQuotesOnly: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY, "false"))

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -229,6 +229,14 @@ private[snowflake] class JDBCWrapper {
       }
     }
 
+    // Setup query result format explicitly because this option is not supported
+    // to be set with JDBC properties
+    if (params.supportAWSStageEndPoint) {
+      params.getS3StageVpceDnsName.map {
+        x => conn.createStatement().execute(s"alter session set S3_STAGE_VPCE_DNS_NAME = '$x'")
+      }
+    }
+
     // Send client info telemetry message.
     val extraValues = Map(TelemetryClientInfoFields.SFURL -> sfURL)
     SnowflakeTelemetry.sendClientInfoTelemetry(extraValues, conn)

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SFInternalStage.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SFInternalStage.scala
@@ -172,4 +172,6 @@ private[io] class SFInternalStage(isWrite: Boolean,
       connection.getSFBaseSession.getUseRegionalS3EndpointsForPresignedURL
 
   private[io] def getRegion: String = sfAgent.getStageInfo.getRegion
+
+  private[io] def getStageEndpoint: String = sfAgent.getStageInfo.getEndPoint
 }


### PR DESCRIPTION
SNOW-608021 Support S3 VPCE deployment

1. Add a new parameter `S3_STAGE_VPCE_DNS_NAME`. If it is configured, SC will set it for the session.
2. For writing to snowflake, SC needs below changes:
    a. GS will send the stage endpoint for `put` command to JDBC. SC driver gets it from JDBC.
    b. SC driver passes it to SC executors
    c. When SC executor uploads data to the stage, it uses the stage endpoint for uploading.
3. For reading from snowflake, SC dons't need any change because JDBC is used to download the result chunks.

NOTE:
I can only test VPCE support manually because the test with it need VPN to `US West`.
