### PR TITLE
SNOW-691776 Bump versions

### DIFF
--- a/.github/workflows/ClusterTest.yml
+++ b/.github/workflows/ClusterTest.yml
@@ -22,8 +22,8 @@ jobs:
         DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.3.0'
         TEST_SCALA_VERSION: '2.12'
         TEST_COMPILE_SCALA_VERSION: '2.12.11'
-        TEST_SPARK_CONNECTOR_VERSION: '2.11.0'
-        TEST_JDBC_VERSION: '3.13.22'
+        TEST_SPARK_CONNECTOR_VERSION: '2.11.1'
+        TEST_JDBC_VERSION: '3.13.24'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/IntegrationTest_2.13.yml
+++ b/.github/workflows/IntegrationTest_2.13.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
      matrix:
-       scala_version: [ '2.13.7' ]
+       scala_version: [ '2.13.9' ]
        spark_version: [ '3.3.0' ]
        use_copy_unload: [ 'true', 'false' ]
        cloud_provider: [ 'aws', 'azure' ]

--- a/.github/workflows/IntegrationTest_gcp_2.13.yml
+++ b/.github/workflows/IntegrationTest_gcp_2.13.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
      matrix:
-       scala_version: [ '2.13.7' ]
+       scala_version: [ '2.13.9' ]
        spark_version: [ '3.3.0' ]
        use_copy_unload: [ 'false' ]
        cloud_provider: [ 'gcp' ]

--- a/ClusterTest/build.sbt
+++ b/ClusterTest/build.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-val sparkConnectorVersion = "2.11.0"
+val sparkConnectorVersion = "2.11.1"
 val scalaVersionMajor = "2.12"
 val sparkVersionMajor = "3.3"
 val sparkVersion = s"${sparkVersionMajor}.0"
@@ -37,7 +37,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.8",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.22",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.24",
       // "net.snowflake" %% "spark-snowflake" % "2.8.0-spark_3.0",
       // "com.google.guava" % "guava" % "14.0.1" % Test,
       // "org.scalatest" %% "scalatest" % "3.0.5" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.3.0")
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.11.0"
+val sparkConnectorVersion = "2.11.1"
 
 lazy val ItTest = config("it") extend Test
 
@@ -44,7 +44,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
     version := s"${sparkConnectorVersion}-spark_3.3",
     scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = "2.12.11"),
     // Spark 3.2 supports scala 2.12 and 2.13
-    crossScalaVersions := Seq("2.12.11", "2.13.7"),
+    crossScalaVersions := Seq("2.12.11", "2.13.9"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
@@ -52,7 +52,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.8",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.22",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.24",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test,
       "org.mockito" % "mockito-core" % "1.10.19" % Test,
       "org.apache.commons" % "commons-lang3" % "3.5" % "provided",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -55,12 +55,12 @@ object Utils {
     */
   val SNOWFLAKE_SOURCE_SHORT_NAME = "snowflake"
 
-  val VERSION = "2.11.0"
+  val VERSION = "2.11.1"
 
   /**
     * The certified JDBC version to work with this spark connector version.
     */
-  val CERTIFIED_JDBC_VERSION = "3.13.22"
+  val CERTIFIED_JDBC_VERSION = "3.13.24"
 
   /**
     * Important:


### PR DESCRIPTION
SNOW-691776 Bump versions

1. Update JDBC to use 3.13.24
2. Update SC version to 2.11.1
3. Update Scala 2.13 to 2.13.9

NOTE: Scala 2.13.9 is necessary because there is security issue for 2.13.7.  Refer to https://mvnrepository.com/artifact/org.scala-lang/scala-library/2.13.7