### PR TITLE
SNOW-692659 Add an option to support returning Long for the Decimal(X, 0) column.

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -1603,7 +1603,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
     val df = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option(Parameters.PARAM_TREAT_DECIMAL_X_0_AS_INT, "true")
+      .option(Parameters.PARAM_TREAT_DECIMAL_X_0_AS_LONG, "true")
       .option("query", s"select 1 as a, 2::Decimal(10, 0) as b, 3::Decimal(10, 1) as c")
       .load()
 
@@ -1629,7 +1629,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
       sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(thisConnectorOptionsNoTable)
-        .option(Parameters.PARAM_TREAT_DECIMAL_X_0_AS_INT, "true")
+        .option(Parameters.PARAM_TREAT_DECIMAL_X_0_AS_LONG, "true")
         .option("query", s"select $maxLong10 :: Decimal(38, 0)")
         .load()
         .collect()

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeResultSetRDDSuite.scala
@@ -1603,7 +1603,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
     val df = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option(Parameters.PARAM_TREAT_DECIMAL_X_0_AS_LONG, "true")
+      .option(Parameters.PARAM_TREAT_DECIMAL_AS_LONG, "true")
       .option("query", s"select 1 as a, 2::Decimal(10, 0) as b, 3::Decimal(10, 1) as c")
       .load()
 
@@ -1629,7 +1629,7 @@ class SnowflakeResultSetRDDSuite extends IntegrationSuiteBase {
       sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(thisConnectorOptionsNoTable)
-        .option(Parameters.PARAM_TREAT_DECIMAL_X_0_AS_LONG, "true")
+        .option(Parameters.PARAM_TREAT_DECIMAL_AS_LONG, "true")
         .option("query", s"select $maxLong10 :: Decimal(38, 0)")
         .load()
         .collect()

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -128,6 +128,11 @@ object Parameters {
   val PARAM_USE_AWS_MULTIPLE_PARTS_UPLOAD: String = knownParam(
     "use_aws_multiple_parts_upload"
   )
+  // Treat Decimal(X, 0) as Long when reading from Snowflake
+  // WARNING: if the Decimal value is greater than max value of Long, conversion will happen.
+  val PARAM_TREAT_DECIMAL_X_0_AS_INT: String = knownParam(
+    "treat_decimal_x_0_as_int"
+  )
 
   // Proxy related info
   val PARAM_USE_PROXY: String = knownParam("use_proxy")
@@ -919,6 +924,9 @@ object Parameters {
     }
     def useAwsMultiplePartsUpload: Boolean =
       isTrue(parameters(PARAM_USE_AWS_MULTIPLE_PARTS_UPLOAD))
+
+    def treadDecimalAsLong: Boolean =
+      isTrue(parameters.getOrElse(PARAM_TREAT_DECIMAL_X_0_AS_INT, "false"))
 
     /**
       * Snowflake time output format

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -130,8 +130,8 @@ object Parameters {
   )
   // Treat Decimal(X, 0) as Long when reading from Snowflake
   // WARNING: if the Decimal value is greater than max value of Long, conversion will happen.
-  val PARAM_TREAT_DECIMAL_X_0_AS_LONG: String = knownParam(
-    "treat_decimal_x_0_as_long"
+  val PARAM_TREAT_DECIMAL_AS_LONG: String = knownParam(
+    "treat_decimal_as_long"
   )
 
   // Proxy related info
@@ -926,7 +926,7 @@ object Parameters {
       isTrue(parameters(PARAM_USE_AWS_MULTIPLE_PARTS_UPLOAD))
 
     def treadDecimalAsLong: Boolean =
-      isTrue(parameters.getOrElse(PARAM_TREAT_DECIMAL_X_0_AS_LONG, "false"))
+      isTrue(parameters.getOrElse(PARAM_TREAT_DECIMAL_AS_LONG, "false"))
 
     /**
       * Snowflake time output format

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -130,8 +130,8 @@ object Parameters {
   )
   // Treat Decimal(X, 0) as Long when reading from Snowflake
   // WARNING: if the Decimal value is greater than max value of Long, conversion will happen.
-  val PARAM_TREAT_DECIMAL_X_0_AS_INT: String = knownParam(
-    "treat_decimal_x_0_as_int"
+  val PARAM_TREAT_DECIMAL_X_0_AS_LONG: String = knownParam(
+    "treat_decimal_x_0_as_long"
   )
 
   // Proxy related info
@@ -926,7 +926,7 @@ object Parameters {
       isTrue(parameters(PARAM_USE_AWS_MULTIPLE_PARTS_UPLOAD))
 
     def treadDecimalAsLong: Boolean =
-      isTrue(parameters.getOrElse(PARAM_TREAT_DECIMAL_X_0_AS_INT, "false"))
+      isTrue(parameters.getOrElse(PARAM_TREAT_DECIMAL_X_0_AS_LONG, "false"))
 
     /**
       * Snowflake time output format

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -925,7 +925,7 @@ object Parameters {
     def useAwsMultiplePartsUpload: Boolean =
       isTrue(parameters(PARAM_USE_AWS_MULTIPLE_PARTS_UPLOAD))
 
-    def treadDecimalAsLong: Boolean =
+    def treatDecimalAsLong: Boolean =
       isTrue(parameters.getOrElse(PARAM_TREAT_DECIMAL_AS_LONG, "false"))
 
     /**

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -184,7 +184,7 @@ private[snowflake] class JDBCWrapper {
     jdbcProperties.put("client_session_keep_alive", "true")
 
     // Force DECIMAL for NUMBER (SNOW-33227)
-    if (params.treadDecimalAsLong) {
+    if (params.treatDecimalAsLong) {
       jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "true")
     } else {
       jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "false")

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -184,7 +184,11 @@ private[snowflake] class JDBCWrapper {
     jdbcProperties.put("client_session_keep_alive", "true")
 
     // Force DECIMAL for NUMBER (SNOW-33227)
-    jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "false")
+    if (params.treadDecimalAsLong) {
+      jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "true")
+    } else {
+      jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "false")
+    }
 
     // Add extra properties from sfOptions
     val extraOptions = params.sfExtraOptions


### PR DESCRIPTION
SNOW-692659 Add an option to support returning Long for the Decimal(X, 0) column.

Add a new option: `treat_decimal_as_long` to support returning Long for the Decimal(X, 0) column.
WARNING: if the Decimal value is greater than max value of Long, conversion will happen.