### PR TITLE
SNOW-697966 Close JDBC connection

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -439,12 +439,15 @@ object Utils {
 
   def runQuery(params: Map[String, String], query: String): ResultSet = {
     val conn = getJDBCConnection(params)
-    val resultSerializables =
+    val resultSerializables = try {
       conn.createStatement()
         .executeQuery(query)
         .asInstanceOf[SnowflakeResultSet]
         .getResultSetSerializables(Long.MaxValue)
-    conn.close()
+    } finally {
+      conn.close()
+    }
+
     // Long.MaxValue is passed to getResultSetSerializables(),
     // so it is sure there is only one object in resultSerializables
     val mergedParams = getMergedParameters(params)


### PR DESCRIPTION
SNOW-697966 Close JDBC connection
1. Close connection in SnowflakeRelation.buildScanFromSQL() if schema is non-empty
2. Close connection in SnowflakeRelation.getSnowflakeResultSetRDD() if query failed
3. Close connection in Utils.runQuery if query failed