### PR TITLE
SNOW-763124 Support uploading files with down-scoped token for Gcs

### DIFF
--- a/.github/workflows/ClusterTest.yml
+++ b/.github/workflows/ClusterTest.yml
@@ -22,8 +22,8 @@ jobs:
         DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.3.0'
         TEST_SCALA_VERSION: '2.12'
         TEST_COMPILE_SCALA_VERSION: '2.12.11'
-        TEST_SPARK_CONNECTOR_VERSION: '2.11.2'
-        TEST_JDBC_VERSION: '3.13.29'
+        TEST_SPARK_CONNECTOR_VERSION: '2.11.3'
+        TEST_JDBC_VERSION: '3.13.30'
 
     steps:
     - uses: actions/checkout@v2

--- a/ClusterTest/build.sbt
+++ b/ClusterTest/build.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-val sparkConnectorVersion = "2.11.2"
+val sparkConnectorVersion = "2.11.3"
 val scalaVersionMajor = "2.12"
 val sparkVersionMajor = "3.3"
 val sparkVersion = s"${sparkVersionMajor}.0"
@@ -37,7 +37,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.8",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.29",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.30",
       // "net.snowflake" %% "spark-snowflake" % "2.8.0-spark_3.0",
       // "com.google.guava" % "guava" % "14.0.1" % Test,
       // "org.scalatest" %% "scalatest" % "3.0.5" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val sparkConnectorVersion = "2.11.2"
 lazy val ItTest = config("it") extend Test
 
 // Test to use self-download or self-build JDBC driver
-// unmanagedJars in Compile += file(s"lib/snowflake-jdbc-3.12.12.jar")
+unmanagedJars in Compile += file(s"temp_lib/snowflake-jdbc.jar")
 
 lazy val root = project.withId("spark-snowflake").in(file("."))
   .configs(ItTest)
@@ -60,7 +60,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.8",
-      "net.snowflake" % "snowflake-jdbc" % "3.13.29",
+//      "net.snowflake" % "snowflake-jdbc" % "3.13.29",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test,
       "org.mockito" % "mockito-core" % "1.10.19" % Test,
       "org.apache.commons" % "commons-lang3" % "3.5" % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -26,12 +26,12 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.3.0")
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.11.2"
+val sparkConnectorVersion = "2.11.3"
 
 lazy val ItTest = config("it") extend Test
 
 // Test to use self-download or self-build JDBC driver
-unmanagedJars in Compile += file(s"temp_lib/snowflake-jdbc.jar")
+// unmanagedJars in Compile += file(s"lib/snowflake-jdbc-3.12.12.jar")
 
 lazy val root = project.withId("spark-snowflake").in(file("."))
   .configs(ItTest)
@@ -60,7 +60,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "net.snowflake" % "snowflake-ingest-sdk" % "0.10.8",
-//      "net.snowflake" % "snowflake-jdbc" % "3.13.29",
+      "net.snowflake" % "snowflake-jdbc" % "3.13.30",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test,
       "org.mockito" % "mockito-core" % "1.10.19" % Test,
       "org.apache.commons" % "commons-lang3" % "3.5" % "provided",

--- a/src/it/scala/net/snowflake/spark/snowflake/CloudStorageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/CloudStorageSuite.scala
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2015-2019 Snowflake Computing
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.snowflake.spark.snowflake
+
+import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
+import net.snowflake.spark.snowflake.test.TestHook
+import org.apache.spark.sql.{DataFrame, SaveMode}
+
+// scalastyle:off println
+class CloudStorageSuite extends IntegrationSuiteBase {
+
+  import testImplicits._
+
+  private val test_table1: String = s"test_temp_table_$randomSuffix"
+  private val test_table_large_result: String =
+    s"test_table_large_result_$randomSuffix"
+  private val test_table_write: String = s"test_table_write_$randomSuffix"
+  private lazy val localDF: DataFrame = Seq((1000, "str11"), (2000, "str22")).toDF("c1", "c2")
+
+  private val largeStringValue =
+    s"""spark_connector_test_large_result_1234567890
+       |spark_connector_test_large_result_1234567890
+       |spark_connector_test_large_result_1234567890
+       |spark_connector_test_large_result_1234567890
+       |spark_connector_test_large_result_1234567890
+       |spark_connector_test_large_result_1234567890
+       |spark_connector_test_large_result_1234567890
+       |spark_connector_test_large_result_1234567890
+       |""".stripMargin.filter(_ >= ' ')
+  private val LARGE_TABLE_ROW_COUNT = 900000
+  lazy val setupLargeResultTable = {
+    jdbcUpdate(
+      s"""create or replace table $test_table_large_result (
+         | int_c int, c_string string(1024) )""".stripMargin)
+
+    jdbcUpdate(
+      s"""insert into $test_table_large_result select
+         | row_number() over (order by seq4()) - 1, '$largeStringValue'
+         | from table(generator(rowcount => $LARGE_TABLE_ROW_COUNT))""".stripMargin)
+    true
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      jdbcUpdate(s"drop table if exists $test_table1")
+      jdbcUpdate(s"drop table if exists $test_table_large_result")
+      jdbcUpdate(s"drop table if exists $test_table_write")
+    } finally {
+      TestHook.disableTestHook()
+      super.afterAll()
+    }
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    jdbcUpdate(s"create or replace table $test_table1(c1 int, c2 string)")
+    jdbcUpdate(s"insert into $test_table1 values (100, 'str1'),(200, 'str2')")
+  }
+
+  private def getHashAgg(tableName: String): java.math.BigDecimal =
+    sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(connectorOptionsNoTable)
+      .option("query", s"select HASH_AGG(*) from $tableName")
+      .load()
+      .collect()(0).getDecimal(0)
+
+  private def getRowCount(tableName: String): Long =
+    sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(connectorOptionsNoTable)
+      .option("dbtable", tableName)
+      .load()
+      .count()
+
+  test("write a small DataFrame to GCS with down-scoped-token") {
+    // Only run this test on GCS
+    if ("gcp".equals(System.getenv("SNOWFLAKE_TEST_ACCOUNT"))) {
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table1)
+        .load()
+
+      // write a small DataFrame to a snowflake table
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table_write)
+        // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+        // The default value of GCS_USE_DOWNSCOPED_CREDENTIAL will be true from Dec 2023
+        // The option set can be removed after Dec 2023
+        .option("GCS_USE_DOWNSCOPED_CREDENTIAL", "true")
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      // Check the source table and target table has same agg_hash.
+      assert(getHashAgg(test_table1) == getHashAgg(test_table_write))
+    } else {
+      println("skip test for non-GCS platform: " +
+        "write a small DataFrame to GCS with down-scoped-token")
+    }
+  }
+
+  test("write a big DataFrame to GCS with down-scoped-token") {
+    // Only run this test on GCS
+    if ("gcp".equals(System.getenv("SNOWFLAKE_TEST_ACCOUNT"))) {
+      setupLargeResultTable
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("partition_size_in_mb", 1) // generate multiple partitions
+        .option("dbtable", test_table_large_result)
+        .load()
+
+      // write a small DataFrame to a snowflake table
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table_write)
+        // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+        // The default value of GCS_USE_DOWNSCOPED_CREDENTIAL will be true from Dec 2023
+        // The option set can be removed after Dec 2023
+        .option("GCS_USE_DOWNSCOPED_CREDENTIAL", "true")
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      // Check the source table and target table has same agg_hash.
+      assert(getHashAgg(test_table_large_result) == getHashAgg(test_table_write))
+    } else {
+      println("skip test for non-GCS platform: " +
+        "write a big DataFrame to GCS with down-scoped-token")
+    }
+  }
+
+  test("write a empty DataFrame to GCS with down-scoped-token") {
+    // Only run this test on GCS
+    if ("gcp".equals(System.getenv("SNOWFLAKE_TEST_ACCOUNT"))) {
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("query", s"select * from $test_table1 where 1 = 2")
+        .load()
+
+      // write a small DataFrame to a snowflake table
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table_write)
+        // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+        // The default value of GCS_USE_DOWNSCOPED_CREDENTIAL will be true from Dec 2023
+        // The option set can be removed after Dec 2023
+        .option("GCS_USE_DOWNSCOPED_CREDENTIAL", "true")
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      // Check the source table and target table has same agg_hash.
+      assert(getRowCount(test_table_write) == 0)
+    } else {
+      println("skip test for non-GCS platform: " +
+        "write a empty DataFrame to GCS with down-scoped-token")
+    }
+  }
+
+  // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+  // Only the snowflake test account can set it for testing purpose.
+  // From Dec 2023, GCS_USE_DOWNSCOPED_CREDENTIAL may be configured as true for all deployments
+  // and this test case can be removed at that time.
+  test("write a small DataFrame to GCS with presigned-url (Can be removed by Dec 2023)") {
+    // Only run this test on GCS
+    if ("gcp".equals(System.getenv("SNOWFLAKE_TEST_ACCOUNT"))) {
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table1)
+        .load()
+
+      // write a small DataFrame to a snowflake table
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table_write)
+        // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+        // The default value of GCS_USE_DOWNSCOPED_CREDENTIAL will be true from Dec 2023
+        // The option set can be removed after Dec 2023
+        .option("GCS_USE_DOWNSCOPED_CREDENTIAL", "false")
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      // Check the source table and target table has same agg_hash.
+      assert(getHashAgg(test_table1) == getHashAgg(test_table_write))
+    } else {
+      println("skip test for non-GCS platform: " +
+        "write a small DataFrame to GCS with presigned-url (Can be removed by Dec 2023)")
+    }
+  }
+
+  // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+  // Only the snowflake test account can set it for testing purpose.
+  // From Dec 2023, GCS_USE_DOWNSCOPED_CREDENTIAL may be configured as true for all deployments
+  // and this test case can be removed at that time.
+  test("write a big DataFrame to GCS with presigned-url (Can be removed by Dec 2023)") {
+    // Only run this test on GCS
+    if ("gcp".equals(System.getenv("SNOWFLAKE_TEST_ACCOUNT"))) {
+      setupLargeResultTable
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("partition_size_in_mb", 1) // generate multiple partitions
+        .option("dbtable", test_table_large_result)
+        .load()
+
+      // write a small DataFrame to a snowflake table
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table_write)
+        // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+        // The default value of GCS_USE_DOWNSCOPED_CREDENTIAL will be true from Dec 2023
+        // The option set can be removed after Dec 2023
+        .option("GCS_USE_DOWNSCOPED_CREDENTIAL", "false")
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      // Check the source table and target table has same agg_hash.
+      assert(getHashAgg(test_table_large_result) == getHashAgg(test_table_write))
+    } else {
+      println("skip test for non-GCS platform: " +
+        "write a big DataFrame to GCS with presigned-url (Can be removed by Dec 2023)")
+    }
+  }
+
+  // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+  // Only the snowflake test account can set it for testing purpose.
+  // From Dec 2023, GCS_USE_DOWNSCOPED_CREDENTIAL may be configured as true for all deployments
+  // and this test case can be removed at that time.
+  test("write a empty DataFrame to GCS with presigned-url (Can be removed by Dec 2023)") {
+    // Only run this test on GCS
+    if ("gcp".equals(System.getenv("SNOWFLAKE_TEST_ACCOUNT"))) {
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("query", s"select * from $test_table1 where 1 = 2")
+        .load()
+
+      // write a small DataFrame to a snowflake table
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(connectorOptionsNoTable)
+        .option("dbtable", test_table_write)
+        // GCS_USE_DOWNSCOPED_CREDENTIAL is not a public parameter, user can't set it.
+        // The default value of GCS_USE_DOWNSCOPED_CREDENTIAL will be true from Dec 2023
+        // The option set can be removed after Dec 2023
+        .option("GCS_USE_DOWNSCOPED_CREDENTIAL", "false")
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      // Check the source table and target table has same agg_hash.
+      assert(getRowCount(test_table_write) == 0)
+    } else {
+      println("skip test for non-GCS platform: " +
+        "write a empty DataFrame to GCS with presigned-url (Can be removed by Dec 2023)")
+    }
+  }
+}
+// scalastyle:on println

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -55,12 +55,12 @@ object Utils {
     */
   val SNOWFLAKE_SOURCE_SHORT_NAME = "snowflake"
 
-  val VERSION = "2.11.2"
+  val VERSION = "2.11.3"
 
   /**
     * The certified JDBC version to work with this spark connector version.
     */
-  val CERTIFIED_JDBC_VERSION = "3.13.29"
+  val CERTIFIED_JDBC_VERSION = "3.13.30"
 
   /**
     * Important:


### PR DESCRIPTION
SNOW-763124 Support uploading files with down-scoped token for Snowflake Gcs accounts

The GCS down-scoped token support needs both JDBC and SC to change.
The JDBC change has been included in JDBC 3.13.30. https://github.com/snowflakedb/snowflake-jdbc/pull/1316

This PR also includes:
1. Upgrade the JDBC and SC version to 3.13.30 and 2.11.3.
2. Enhance SC to support down-scoped token for GCP.

The design is https://docs.google.com/document/d/1MlGUyoFOAYEJx6skw2KZfduKp1EPQIJ2SFdsm3emOJ4/edit#
