### PR TITLE
SNOW-796952 Add option to disable pre- and post-action validation for session sharing

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -229,6 +229,14 @@ object Parameters {
     "support_share_connection"
   )
 
+  // preactions and postactions may affect the session level setting, so connection sharing
+  // may be enabled only when the queries in preactions and postactions are in a white list.
+  // force_skip_pre_post_action_check_for_session_sharing is introduced if users are sure that
+  // the queries in preactions and postactions don't affect others. Its default value is false.
+  val PARAM_FORCE_SKIP_PRE_POST_ACTION_CHECK_FOR_SESSION_SHARING: String = knownParam(
+    "force_skip_pre_post_action_check_for_session_sharing"
+  )
+
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
 
@@ -705,6 +713,10 @@ object Parameters {
     }
     def supportShareConnection: Boolean = {
       isTrue(parameters.getOrElse(PARAM_SUPPORT_SHARE_CONNECTION, "true"))
+    }
+    def forceSkipPrePostActionsCheck: Boolean = {
+      isTrue(parameters.getOrElse(
+        PARAM_FORCE_SKIP_PRE_POST_ACTION_CHECK_FOR_SESSION_SHARING, "false"))
     }
     def stagingTableNameRemoveQuotesOnly: Boolean = {
       isTrue(parameters.getOrElse(PARAM_INTERNAL_STAGING_TABLE_NAME_REMOVE_QUOTES_ONLY, "false"))

--- a/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
@@ -23,6 +23,7 @@ sealed class ConnectionCacheKey(private val parameters: MergedParameters) {
     "overwrite",
     Parameters.PARAM_POSTACTIONS,
     Parameters.PARAM_PREACTIONS,
+    Parameters.PARAM_FORCE_SKIP_PRE_POST_ACTION_CHECK_FOR_SESSION_SHARING,
     Parameters.PARAM_SF_QUERY,
     Parameters.PARAM_SF_DBTABLE
   )
@@ -69,12 +70,16 @@ sealed class ConnectionCacheKey(private val parameters: MergedParameters) {
     }
   }
 
+  private[snowflake] def isPrePostActionsQualifiedForConnectionShare: Boolean =
+    parameters.forceSkipPrePostActionsCheck ||
+      (parameters.preActions.forall(isQueryInWhiteList) &&
+        parameters.postActions.forall(isQueryInWhiteList))
+
   def isConnectionCacheSupported: Boolean = {
     // Support sharing connection if pre/post actions doesn't change context
     ServerConnection.supportSharingJDBCConnection &&
       parameters.supportShareConnection &&
-      parameters.preActions.forall(isQueryInWhiteList) &&
-      parameters.postActions.forall(isQueryInWhiteList)
+      isPrePostActionsQualifiedForConnectionShare
   }
 }
 

--- a/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
@@ -284,4 +284,20 @@ class ParametersSuite extends FunSuite with Matchers {
     connectionCacheKey = new ConnectionCacheKey(mergedParams)
     assert(!connectionCacheKey.isConnectionCacheSupported)
   }
+
+  test("test ConnectionCacheKey.isPrePostActionsQualifiedForConnectionShare()") {
+    val listQuery1 = "create database db1"
+    val mergedParams = Parameters.mergeParameters(
+      minParams ++ Map(Parameters.PARAM_POSTACTIONS -> listQuery1))
+    assert(!mergedParams.forceSkipPrePostActionsCheck)
+    val connectionCacheKey = new ConnectionCacheKey(mergedParams)
+    assert(!connectionCacheKey.isPrePostActionsQualifiedForConnectionShare)
+
+    val mergedParamsEnabled = Parameters.mergeParameters(minParams ++
+      Map(Parameters.PARAM_FORCE_SKIP_PRE_POST_ACTION_CHECK_FOR_SESSION_SHARING -> "true",
+        Parameters.PARAM_POSTACTIONS -> listQuery1))
+    assert(mergedParamsEnabled.forceSkipPrePostActionsCheck)
+    val forceEnabledConnectionCacheKey = new ConnectionCacheKey(mergedParamsEnabled)
+    assert(forceEnabledConnectionCacheKey.isPrePostActionsQualifiedForConnectionShare)
+  }
 }


### PR DESCRIPTION
SNOW-796952 Add option to disable pre- and post-action validation for session sharing.

The option name is `FORCE_SKIP_PRE_POST_ACTION_CHECK_FOR_SHARED_SESSION`. The default is false.

`preactions` and `postactions` may affect the session level setting, so connection sharing
may be enabled only when the queries in `preactions` and `postactions` are in a white list.
`FORCE_SKIP_PRE_POST_ACTION_CHECK_FOR_SHARED_SESSION` is introduced if users are sure that
the queries in `preactions` and `postactions` don't affect others.
