### PR TITLE
SNOW-824475 Support Spark 3.4

### DIFF
--- a/.github/workflows/ClusterTest.yml
+++ b/.github/workflows/ClusterTest.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       matrix:
         scala_version: [ '2.12.11' ]
-        spark_version: [ '3.3.0' ]
+        spark_version: [ '3.4.0' ]
         use_copy_unload: [ 'true' ]
         cloud_provider: [ 'gcp' ]
     env:
         SNOWFLAKE_TEST_CONFIG_SECRET: ${{ secrets.SNOWFLAKE_TEST_CONFIG_SECRET }}
-        TEST_SPARK_VERSION: '3.3'
-        DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.3.0'
+        TEST_SPARK_VERSION: '3.4'
+        DOCKER_IMAGE_TAG: 'snowflakedb/spark-base:3.4.0'
         TEST_SCALA_VERSION: '2.12'
         TEST_COMPILE_SCALA_VERSION: '2.12.11'
         TEST_SPARK_CONNECTOR_VERSION: '2.11.3'

--- a/.github/workflows/IntegrationTest_2.12.yml
+++ b/.github/workflows/IntegrationTest_2.12.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.12.11' ]
-       spark_version: [ '3.3.0' ]
+       spark_version: [ '3.4.0' ]
        use_copy_unload: [ 'true', 'false' ]
        cloud_provider: [ 'aws', 'azure' ]
        # run_query_in_async can be removed after async mode is stable

--- a/.github/workflows/IntegrationTest_2.13.yml
+++ b/.github/workflows/IntegrationTest_2.13.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.13.9' ]
-       spark_version: [ '3.3.0' ]
+       spark_version: [ '3.4.0' ]
        use_copy_unload: [ 'true', 'false' ]
        cloud_provider: [ 'aws', 'azure' ]
        # run_query_in_async can be removed after async mode is stable

--- a/.github/workflows/IntegrationTest_gcp_2.12.yml
+++ b/.github/workflows/IntegrationTest_gcp_2.12.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.12.11' ]
-       spark_version: [ '3.3.0' ]
+       spark_version: [ '3.4.0' ]
        use_copy_unload: [ 'false' ]
        cloud_provider: [ 'gcp' ]
        # run_query_in_async can be removed after async mode is stable

--- a/.github/workflows/IntegrationTest_gcp_2.13.yml
+++ b/.github/workflows/IntegrationTest_gcp_2.13.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
      matrix:
        scala_version: [ '2.13.9' ]
-       spark_version: [ '3.3.0' ]
+       spark_version: [ '3.4.0' ]
        use_copy_unload: [ 'false' ]
        cloud_provider: [ 'gcp' ]
        # run_query_in_async can be removed after async mode is stable

--- a/ClusterTest/build.sbt
+++ b/ClusterTest/build.sbt
@@ -16,7 +16,7 @@
 
 val sparkConnectorVersion = "2.11.3"
 val scalaVersionMajor = "2.12"
-val sparkVersionMajor = "3.3"
+val sparkVersionMajor = "3.4"
 val sparkVersion = s"${sparkVersionMajor}.0"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,8 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3.3"
-val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.3.0")
+val sparkVersion = "3.4"
+val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.4.0")
 
 /*
  * Don't change the variable name "sparkConnectorVersion" because
@@ -41,7 +41,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
   .settings(
     name := "spark-snowflake",
     organization := "net.snowflake",
-    version := s"${sparkConnectorVersion}-spark_3.3",
+    version := s"${sparkConnectorVersion}-spark_3.4",
     scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = "2.12.11"),
     // Spark 3.2 supports scala 2.12 and 2.13
     crossScalaVersions := Seq("2.12.11", "2.13.9"),

--- a/src/it/scala/net/snowflake/spark/snowflake/SimpleNewPushdownIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SimpleNewPushdownIntegrationSuite.scala
@@ -334,15 +334,22 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
     var result =
       sparkSession.sql(s"select o $operator p from df2 where o IS NOT NULL")
 
-    testPushdown(
+    val expectedAdditionQueries = Seq(
       s"""SELECT ( CAST ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" )
-                    |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
-                    |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
-                    |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
-                    |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+         |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
       """.stripMargin,
-      result,
-      // Data in df2 (o, p) values(null, 1), (2, 2), (3, 2), (4, 3)
+      // From spark 3.4, the CAST operation is not presented in the plan
+      s"""SELECT ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+      """.stripMargin
+    )
+
+    testPushdownMultiplefQueries(expectedAdditionQueries, result,
       Seq(Row(4), Row(5), Row(7)),
       disablePushDown
     )
@@ -352,14 +359,22 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
     result =
       sparkSession.sql(s"select o $operator p from df2 where o IS NOT NULL")
 
-    testPushdown(
+    val expectedSubtractQueries = Seq(
       s"""SELECT ( CAST ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" )
-                    |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
-                    |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
-                    |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
-                    |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+         |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
       """.stripMargin,
-      result,
+      // From spark 3.4, the CAST operation is not presented in the plan
+      s"""SELECT ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+      """.stripMargin
+    )
+
+    testPushdownMultiplefQueries(expectedSubtractQueries, result,
       // Data in df2 (o, p) values(null, 1), (2, 2), (3, 2), (4, 3)
       Seq(Row(0), Row(1), Row(1)),
       disablePushDown
@@ -370,15 +385,22 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
     result =
       sparkSession.sql(s"select o $operator p from df2 where o IS NOT NULL")
 
-    testPushdown(
+    val expectedMultiplyQueries = Seq(
       s"""SELECT ( CAST ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" )
-                    |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
-                    |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
-                    |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
-                    |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+         |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
       """.stripMargin,
-      result,
-      // Data in df2 (o, p) values(null, 1), (2, 2), (3, 2), (4, 3)
+      // From spark 3.4, the CAST operation is not presented in the plan
+      s"""SELECT ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+      """.stripMargin
+    )
+
+    testPushdownMultiplefQueries(expectedMultiplyQueries, result,
       Seq(Row(4), Row(6), Row(12)),
       disablePushDown
     )
@@ -388,15 +410,22 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
     result =
       sparkSession.sql(s"select o $operator p from df2 where o IS NOT NULL")
 
-    testPushdown(
+    val expectedDivisionQueries = Seq(
       s"""SELECT ( CAST ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" )
-                    |AS DECIMAL(38, 6) ) ) AS "SUBQUERY_2_COL_0" FROM
-                    |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
-                    |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
-                    |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+         |AS DECIMAL(38, 6) ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
       """.stripMargin,
-      result,
-      // Data in df2 (o, p) values(null, 1), (2, 2), (3, 2), (4, 3)
+      // From spark 3.4, the CAST operation is not presented in the plan
+      s"""SELECT ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+      """.stripMargin
+    )
+
+    testPushdownMultiplefQueries(expectedDivisionQueries, result,
       Seq(Row(1.000000), Row(1.333333), Row(1.500000)),
       disablePushDown
     )
@@ -406,15 +435,22 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
     result =
       sparkSession.sql(s"select o $operator p from df2 where o IS NOT NULL")
 
-    testPushdown(
+    val expectedModQueries = Seq(
       s"""SELECT ( CAST ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" )
-                    |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
-                    |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
-                    |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
-                    |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+         |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
       """.stripMargin,
-      result,
-      // Data in df2 (o, p) values(null, 1), (2, 2), (3, 2), (4, 3)
+      // From spark 3.4, the CAST operation is not presented in the plan
+      s"""SELECT ( ( "SUBQUERY_1"."O" $operator "SUBQUERY_1"."P" ) ) AS "SUBQUERY_2_COL_0" FROM
+         |( SELECT * FROM ( SELECT * FROM ( $test_table2 ) AS
+         |"SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE
+         |( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+      """.stripMargin
+    )
+
+    testPushdownMultiplefQueries(expectedModQueries, result,
       Seq(Row(0), Row(1), Row(1)),
       disablePushDown
     )
@@ -425,18 +461,28 @@ class SimpleNewPushdownIntegrationSuite extends IntegrationSuiteBase {
       s"select -o, - o + p, - o - p, - ( o + p ), - 3 + o from df2 where o IS NOT NULL"
     )
 
-    testPushdown(
+    val expectedUnaryMinusQueries = Seq(
       s"""SELECT ( - ( "SUBQUERY_1"."O" ) ) AS "SUBQUERY_2_COL_0" , ( CAST (
-                    |( - ( "SUBQUERY_1"."O" ) + "SUBQUERY_1"."P" ) AS DECIMAL(38, 0) ) )
-                    |AS "SUBQUERY_2_COL_1" , ( CAST ( ( - ( "SUBQUERY_1"."O" ) - "SUBQUERY_1"."P" )
-                    |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_2" , ( - ( CAST ( ( "SUBQUERY_1"."O"
-                    |+ "SUBQUERY_1"."P" ) AS DECIMAL(38, 0) ) ) ) AS "SUBQUERY_2_COL_3" , ( CAST ( (
-                    |-3 + "SUBQUERY_1"."O" ) AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_4" FROM ( SELECT
-                    |* FROM ( SELECT * FROM ( $test_table2 ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS
-                    |"SUBQUERY_0" WHERE ( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+         |( - ( "SUBQUERY_1"."O" ) + "SUBQUERY_1"."P" ) AS DECIMAL(38, 0) ) )
+         |AS "SUBQUERY_2_COL_1" , ( CAST ( ( - ( "SUBQUERY_1"."O" ) - "SUBQUERY_1"."P" )
+         |AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_2" , ( - ( CAST ( ( "SUBQUERY_1"."O"
+         |+ "SUBQUERY_1"."P" ) AS DECIMAL(38, 0) ) ) ) AS "SUBQUERY_2_COL_3" , ( CAST ( (
+         |-3 + "SUBQUERY_1"."O" ) AS DECIMAL(38, 0) ) ) AS "SUBQUERY_2_COL_4" FROM ( SELECT
+         |* FROM ( SELECT * FROM ( $test_table2 ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS
+         |"SUBQUERY_0" WHERE ( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
       """.stripMargin,
-      result,
-      // Data in df2 (o, p) values(2, 2), (3, 2), (4, 3)
+      // From spark 3.4, the CAST operation is not presented in the plan
+      s"""SELECT ( - ( "SUBQUERY_1"."O" ) ) AS "SUBQUERY_2_COL_0" ,
+         | ( ( - ( "SUBQUERY_1"."O" ) + "SUBQUERY_1"."P" ) ) AS "SUBQUERY_2_COL_1" ,
+         | ( ( - ( "SUBQUERY_1"."O" ) - "SUBQUERY_1"."P" ) ) AS "SUBQUERY_2_COL_2" ,
+         | ( - ( ( "SUBQUERY_1"."O" + "SUBQUERY_1"."P" ) ) ) AS "SUBQUERY_2_COL_3" ,
+         | ( ( -3 + "SUBQUERY_1"."O" ) ) AS "SUBQUERY_2_COL_4"
+         | FROM ( SELECT * FROM ( SELECT * FROM (  $test_table2 ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS
+         | "SUBQUERY_0" WHERE ( "SUBQUERY_0"."O" IS NOT NULL ) ) AS "SUBQUERY_1"
+      """.stripMargin
+    )
+
+    testPushdownMultiplefQueries(expectedUnaryMinusQueries, result,
       Seq(
         Row(-2, 0, -4, -4, -1),
         Row(-3, -1, -5, -5, 0),

--- a/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFramesSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFramesSuite.scala
@@ -1,5 +1,6 @@
 package org.apache.spark.sql
 
+import net.snowflake.spark.snowflake.{SnowflakeConnectorUtils, TestUtils}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.snowflake.{SFQueryTest, SFTestData, SFTestSessionBase}
@@ -167,23 +168,41 @@ class SFDataFrameWindowFramesSuite
           window.rangeBetween(Window.unboundedPreceding, Window.unboundedFollowing))),
       Row("non_numeric", "non_numeric") :: Nil)
 
+    // The error message for 3.4 is different.
+    val expectedErrorMessage1 =
+      if (TestUtils.compareVersion(SnowflakeConnectorUtils.SUPPORT_SPARK_VERSION, "3.4") >= 0) {
+      "The data type of the upper bound \"STRING\" does not match the expected data type"
+    } else {
+      "The data type of the upper bound 'string' does not match the expected data type"
+    }
     val e1 = intercept[AnalysisException](
       df.select(
         min("value").over(window.rangeBetween(Window.unboundedPreceding, 1))))
-    assert(e1.message.contains("The data type of the upper bound 'string' " +
-      "does not match the expected data type"))
+    assert(e1.message.contains(expectedErrorMessage1))
 
+    // The error message for 3.4 is different.
+    val expectedErrorMessage2 =
+      if (TestUtils.compareVersion(SnowflakeConnectorUtils.SUPPORT_SPARK_VERSION, "3.4") >= 0) {
+        "The data type of the lower bound \"STRING\" does not match the expected data type"
+      } else {
+        "The data type of the lower bound 'string' does not match the expected data type"
+      }
     val e2 = intercept[AnalysisException](
       df.select(
         min("value").over(window.rangeBetween(-1, Window.unboundedFollowing))))
-    assert(e2.message.contains("The data type of the lower bound 'string' " +
-      "does not match the expected data type"))
+    assert(e2.message.contains(expectedErrorMessage2))
 
+    // The error message for 3.4 is different.
+    val expectedErrorMessage3 =
+      if (TestUtils.compareVersion(SnowflakeConnectorUtils.SUPPORT_SPARK_VERSION, "3.4") >= 0) {
+        "The data type of the lower bound \"STRING\" does not match the expected data type"
+      } else {
+        "The data type of the lower bound 'string' does not match the expected data type"
+      }
     val e3 = intercept[AnalysisException](
       df.select(
         min("value").over(window.rangeBetween(-1, 1))))
-    assert(e3.message.contains("The data type of the lower bound 'string' " +
-      "does not match the expected data type"))
+    assert(e3.message.contains(expectedErrorMessage3))
   }
 
   test("range between should accept int/long values as boundary") {

--- a/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFunctionsSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDataFrameWindowFunctionsSuite.scala
@@ -33,7 +33,7 @@ class SFDataFrameWindowFunctionsSuite
     }
   }
 
-  protected lazy val sql = spark.sql _
+  protected def sql(sqlText: String) = spark.sql(sqlText)
 
   override def spark: SparkSession = getSnowflakeSession()
 

--- a/src/it/scala/org/apache/spark/sql/SFDateFunctionsSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SFDateFunctionsSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 class SFDateFunctionsSuite extends SFQueryTest with SFTestSessionBase {
   import SFTestImplicits._
-  protected lazy val sql = spark.sql _
+  protected def sql(sqlText: String) = spark.sql(sqlText)
 
   test("function current_date") {
     val df1 = Seq((1, 2), (3, 1)).toDF("a", "b")

--- a/src/it/scala/org/apache/spark/sql/SnowflakeSparkUtilsSuite.scala
+++ b/src/it/scala/org/apache/spark/sql/SnowflakeSparkUtilsSuite.scala
@@ -9,7 +9,7 @@ class SnowflakeSparkUtilsSuite extends SFQueryTest with SFTestSessionBase {
 
   import SFTestImplicits._
 
-  protected lazy val sql = spark.sql _
+  protected def sql(sqlText: String) = spark.sql(sqlText)
 
   test("unit test: SnowflakeSparkUtils.getJDBCProviderName") {
     assert(SnowflakeSparkUtils.getJDBCProviderName(

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -34,7 +34,7 @@ object SnowflakeConnectorUtils {
     * Check Spark version, if Spark version matches SUPPORT_SPARK_VERSION enable PushDown,
     * otherwise disable it.
     */
-  val SUPPORT_SPARK_VERSION = "3.3"
+  val SUPPORT_SPARK_VERSION = "3.4"
 
   def checkVersionAndEnablePushdown(session: SparkSession): Boolean =
     if (session.version.startsWith(SUPPORT_SPARK_VERSION)) {

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
@@ -24,7 +24,8 @@ import org.apache.spark.sql.catalyst.expressions.{
   Log,
   Pi,
   Pow,
-  PromotePrecision,
+  // PromotePrecision is removed from Spark 3.4
+  // PromotePrecision,
   Rand,
   Round,
   Sin,
@@ -75,7 +76,9 @@ private[querygeneration] object NumericStatement {
             )
           )
 
-      case PromotePrecision(child) => convertStatement(child, fields)
+      // PromotePrecision is removed from Spark 3.4
+      // https://github.com/apache/spark/pull/36698
+      // case PromotePrecision(child) => convertStatement(child, fields)
 
       case CheckOverflow(child, t, _) =>
         MiscStatement.getCastType(t) match {
@@ -94,7 +97,11 @@ private[querygeneration] object NumericStatement {
         ConstantString("RANDOM") + blockStatement(
           LongVariable(Option(seed).map(_.asInstanceOf[Long])) !
         )
-      case Round(child, scale) =>
+
+      // Spark 3.4 adds a new argument: ansiEnabled
+      // https://github.com/apache/spark/commit/42721120f3c7206a9fc22db5d0bb7cf40f0cacfd
+      // The pushdown is supported for non-ANSI mode.
+      case Round(child, scale, ansiEnabled) if !ansiEnabled =>
         ConstantString("ROUND") + blockStatement(
           convertStatements(fields, child, scale)
         )

--- a/src/test/scala/net/snowflake/spark/snowflake/TestUtils.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/TestUtils.scala
@@ -229,4 +229,18 @@ object TestUtils {
 
   def getServerConnection(connection: Connection): ServerConnection =
     ServerConnection(connection)
+
+  def compareVersion(leftVersion: String, rightVersion: String): Int = {
+    val leftVersionParts = leftVersion.split("\\.").map(_.toLong)
+    val rightVersionParts = rightVersion.split("\\.").map(_.toLong)
+    for (i <- 0 until Math.min(leftVersionParts.length, rightVersionParts.length)) {
+      if (leftVersionParts(i) > rightVersionParts(i)) {
+        return 1
+      } else if (leftVersionParts(i) < rightVersionParts(i)) {
+        return -1
+      }
+    }
+    // 3.1 < 3.1.1
+    leftVersionParts.length - rightVersionParts.length
+  }
 }


### PR DESCRIPTION
SNOW-824475 Support Spark 3.4

The main changes for Spark 3.4 affects Spark Connector are:
1. Change the last argument for `Cast`
    - Old type: `ansiEnabled: Boolean`
    - New Type: `evalMode: EvalMode.Value`
    - Currently, there are 3 modes: `LEGACY`, `ANSI`, `TRY`
    - Support to pushdown, if the mode is `LEGACY`. It will make SC to be in consistent behaviour.
2. Added a `JoinHint` argument for `ScalarSubquery`.
    - Spark Connector only pushdown if joinCont is not empty. So the new parameter can be ignored.
3. `PromotePrecision` is removed from Spark 3.4
    - So SC only needs to remove the process for this pan node.
4. Added a new argument `ansiEnabled` for `Round`.
    - Support to pushdown, if the ansiEnabled is false. It will make SC to be in consistent behaviour.
