### PR TITLE
Remove user parameter for connection using OAuth

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
@@ -157,17 +157,19 @@ private[snowflake] object ServerConnection {
     // Obligatory properties
     jdbcProperties.put("db", params.sfDatabase)
     jdbcProperties.put("schema", params.sfSchema) // Has a default
-    jdbcProperties.put("user", params.sfUser)
 
     params.privateKey match {
       case Some(privateKey) =>
+        jdbcProperties.put("user", params.sfUser)
         jdbcProperties.put("privateKey", privateKey)
       case None =>
-        // Adding OAuth Token parameter
+        // Adding OAuth Token parameter. User parameter is not required in this case
         params.sfToken match {
           case Some(value) =>
             jdbcProperties.put("token", value)
-          case None => jdbcProperties.put("password", params.sfPassword)
+          case None =>
+            jdbcProperties.put("user", params.sfUser)
+            jdbcProperties.put("password", params.sfPassword)
         }
     }
     jdbcProperties.put("ssl", params.sfSSL) // Has a default


### PR DESCRIPTION
Snowflake Spark connector uses the Snowflake JDBC driver under the hood for connection/authentication (as documented). The JDBC connector does not require `user` parameter for connection using OAuth: https://github.com/snowflakedb/snowflake-jdbc/blob/9ecd6578111003c3895dc1165de9711ced8922c1/src/test/java/net/snowflake/client/jdbc/SnowflakeDriverIT.java#L140

OAuth specification does not require a `user` parameter when using `access token`: https://datatracker.ietf.org/doc/html/rfc6749#section-1.4