### PR TITLE
SNOW-903045 Support Dataframe Contains both Binary and Variant Columns

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/VariantTypeSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/VariantTypeSuite.scala
@@ -5,8 +5,6 @@ import org.apache.spark.sql.types._
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import org.apache.spark.sql.{Row, SaveMode}
 
-import scala.collection.Seq
-
 class VariantTypeSuite extends IntegrationSuiteBase {
 
   lazy val schema = new StructType(


### PR DESCRIPTION
Support load a Spark dataframe contains both Binary and Variant columns to Snowflake table.