### PR TITLE
bug: Fix causing program to not display error message in save dataframe

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
@@ -27,6 +27,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import org.apache.spark.sql._
 
+import scala.util.{Failure, Success, Try}
+
 /**
   * Functions to write data to Snowflake.
   *
@@ -70,7 +72,12 @@ private[snowflake] class SnowflakeWriter(jdbcWrapper: JDBCWrapper) {
     }
 
     val output: DataFrame = removeUselessColumns(data, params)
-    val strRDD = dataFrameToRDD(sqlContext, output, params, format)
+    val strRDD: RDD[String] = Try {
+      dataFrameToRDD(sqlContext, output, params, format)
+    } match {
+      case Success(success) => success
+      case Failure(error) => throw error
+    }
     io.writeRDD(sqlContext, params, strRDD, output.schema, saveMode, format)
   }
 
@@ -110,7 +117,7 @@ private[snowflake] class SnowflakeWriter(jdbcWrapper: JDBCWrapper) {
   }
 
   private def prepareSchemaForJson(schema: StructType): StructType =
-    StructType.apply(schema.map{
+    StructType.apply(schema.map {
       // Binary types will be converted to String type before COPY
       case field: StructField if field.dataType == BinaryType =>
         StructField(field.name, StringType, field.nullable, field.metadata)


### PR DESCRIPTION
This commit fixes a bug that caused the program to not display an error message when saving a Spark dataframe to Snowflake. The problem was related to exception catching, which did not display errors that occurred during the save process. As a result, users were unaware of any issues with the saved data and could not take appropriate action to fix them.

To solve this problem, we have added an error handling code to the programme that detects any errors that occur during the saving process and displays an appropriate error message to the user. 

With this fix, users can be confident that any errors that occur during the save process will be correctly reported, allowing them to quickly identify and fix any problems with the saved data. 

Example:
|  column_name |  data_type |  
|---|---|
|  id  |  int  |
|  execution_date  |  timestamp  |

```python
from pyspark.sql.functions import col
df = spark.createDataFrame(
    [{"id": 1, "execution_date": "202022-02-23 19:21:06"}]
).withColumn("execution_date", col("execution_date").cast("timestamp"))

df.show(truncate=False)

df.write.save(
    format="snowflake",
    mode="append",
)
```
error: the error is not displayed
![image](https://github.com/snowflakedb/spark-snowflake/assets/7476964/704caad5-d218-42fe-bd5c-3d819589fc60)

solution: the error is displayed
![image](https://github.com/snowflakedb/spark-snowflake/assets/7476964/b596f465-41a4-4619-8a4d-b77e5a29eae5)
