### PR TITLE
SNOW-1002378 Add new Parameter "string_timestamp_format"

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/DataTypesIntegrationSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/DataTypesIntegrationSuite.scala
@@ -111,7 +111,7 @@ class DataTypesIntegrationSuite extends IntegrationSuiteBase {
 
     val df = sparkSession.read.format(SNOWFLAKE_SOURCE_NAME)
       .options(connectorOptionsNoTable).option("dbtable", test_table).load()
-    assert(df.collect().head.getTimestamp(0).toString.equals("2023-11-28 10:23:59.123456"))
+    assert(df.collect().head.getTimestamp(0).toString.startsWith("2023-11-28 10:23:59.123"))
 
     // it doesn't work if source dataframe has timestamp column
     val dateFormat: DateFormat = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS")

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -114,6 +114,9 @@ object Parameters {
   val PARAM_TIMESTAMP_NTZ_OUTPUT_FORMAT: String = knownParam("timestamp_ntz_output_format")
   val PARAM_TIMESTAMP_LTZ_OUTPUT_FORMAT: String = knownParam("timestamp_ltz_output_format")
   val PARAM_TIMESTAMP_TZ_OUTPUT_FORMAT: String = knownParam("timestamp_tz_output_format")
+  // changed the timestamp format when copy data from string column to timestamp column.
+  // it only works when source dataframe doesn't have timestamp columns.
+  val PARAM_STRING_TIMESTAMP_FORMAT: String = knownParam("string_timestamp_format")
   val TIMESTAMP_OUTPUT_FORMAT_SF_CURRENT: String = "sf_current"
   val PARAM_JDBC_QUERY_RESULT_FORMAT: String = knownParam(
     "jdbc_query_result_format"
@@ -1016,6 +1019,9 @@ object Parameters {
           "ignore"
       }
     }
+
+    def getStringTimestampFormat: Option[String] =
+      parameters.get(PARAM_STRING_TIMESTAMP_FORMAT)
 
     def streamingStage: Option[String] = parameters.get(PARAM_STREAMING_STAGE)
 


### PR DESCRIPTION
- Add a new parameter `string_timestamp_format`
  - It can overwrite the timestamp format when copy from string dataframe column to timestamp snowflake table column.
  - It will be ignored if the source dataframe table has timestamp column