### PR TITLE
SNOW-1012110 Skip Retry after Application Closed

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/SparkConnectorContextSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SparkConnectorContextSuite.scala
@@ -287,6 +287,7 @@ class SparkConnectorContextSuite extends IntegrationSuiteBase {
     Future {
       newSparkSession.read.format(SNOWFLAKE_SOURCE_NAME)
         .options(connectorOptionsNoTable)
+        .option(Parameters.PARAM_SUPPORT_SHARE_CONNECTION, "false")
         .option("query", "select count(*) from table(generator(timelimit=>100))")
         .load().show()
     }

--- a/src/it/scala/net/snowflake/spark/snowflake/SparkConnectorContextSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SparkConnectorContextSuite.scala
@@ -278,28 +278,41 @@ class SparkConnectorContextSuite extends IntegrationSuiteBase {
   }
 
   test("Disable retry after application closed") {
-
-    val newSparkSession = createDefaultSparkSession
-    val sc = newSparkSession.sparkContext
+    val sc = sparkSession.sparkContext
     val appId = sc.applicationId
 
+    val df = sparkSession.read.format(SNOWFLAKE_SOURCE_NAME)
+      .options(connectorOptionsNoTable)
+      .option(Parameters.PARAM_SUPPORT_SHARE_CONNECTION, "false")
+      .option("query", "select count(*) from table(generator(timelimit=>100))")
+      .load()
+
     import scala.concurrent.ExecutionContext.Implicits.global
-    Future {
-      newSparkSession.read.format(SNOWFLAKE_SOURCE_NAME)
-        .options(connectorOptionsNoTable)
-        .option(Parameters.PARAM_SUPPORT_SHARE_CONNECTION, "false")
-        .option("query", "select count(*) from table(generator(timelimit=>100))")
-        .load().show()
+    val f = Future {
+      df.collect()
     }
     Thread.sleep(10000)
     var queries = SparkConnectorContext.getRunningQueries.get(appId)
     assert(queries.isDefined)
     assert(queries.get.size == 1)
-    newSparkSession.stop()
+    sparkSession.stop()
     Thread.sleep(10000)
     queries = SparkConnectorContext.getRunningQueries.get(appId)
     SparkConnectorContext.closedApplicationIDs.contains(appId)
     assert(queries.isEmpty)
-  }
 
+    // Wait for child thread done to avoid affect other test cases.
+    Await.ready(f, Duration.Inf)
+
+    // Recreate spark session to avoid affect following test cases
+    sparkSession = SparkSession.builder
+      .master("local")
+      .appName("SnowflakeSourceSuite")
+      .config("spark.sql.shuffle.partitions", "6")
+      // "spark.sql.legacy.timeParserPolicy = LEGACY" is added to allow
+      // spark 3.0 to support legacy conversion for unix_timestamp().
+      // It may not be necessary for spark 2.X.
+      .config("spark.sql.legacy.timeParserPolicy", "LEGACY")
+      .getOrCreate()
+  }
 }


### PR DESCRIPTION
Spark triggers `onApplicationEnd` listener earlier than stops tasks. Spark connector cancels all running queries in this listener. Therefore, spark will rerun those canceled queries in the retry.
This PR introduces a new checker, to skip those retries after application closed.