### PR TITLE
Add ABORT_DETACHED_QUERY parameter in session prologue query

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -241,6 +241,10 @@ object Parameters {
     "force_skip_pre_post_action_check_for_session_sharing"
   )
 
+  val PARAM_ABORT_DETACHED_QUERY_SESSION_VARIABLE: String = knownParam(
+    "abort_detached_query_session_variable"
+  )
+
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
 
@@ -1049,6 +1053,9 @@ object Parameters {
           )
       }
     }
+
+    def abortDetachedQuerySessionVariable: Boolean =
+      isTrue(parameters.getOrElse(PARAM_ABORT_DETACHED_QUERY_SESSION_VARIABLE, "false"))
   }
 }
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -193,7 +193,7 @@ private[snowflake] case class SnowflakeRelation(
   ): RDD[T] = {
     val conn = DefaultJDBCWrapper.getConnector(params)
     try {
-      Utils.genPrologueSql(params).foreach(x => x.execute(bindVariableEnabled = false)(conn))
+      Utils.genPrologueSql(params).execute(bindVariableEnabled = false)(conn)
       Utils.executePreActions(DefaultJDBCWrapper, conn, params, params.table)
       Utils.setLastSelect(statement.toString)
       log.info(s"Now executing below command to read from snowflake:\n${statement.toString}")

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
@@ -28,7 +28,7 @@ private[snowflake] object StageReader {
     val compress = params.sfCompress
     val compressFormat = if (params.sfCompress) "gzip" else "none"
 
-    Utils.genPrologueSql(params).foreach(x => x.execute(params.bindVariableEnabled)(conn))
+    Utils.genPrologueSql(params).execute(params.bindVariableEnabled)(conn)
 
     Utils.executePreActions(DefaultJDBCWrapper, conn, params, params.table)
 

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -210,7 +210,7 @@ private[io] object StageWriter {
     val conn = DefaultJDBCWrapper.getConnector(params)
 
     try {
-      prologueSql.foreach(x => x.execute(params.bindVariableEnabled)(conn))
+      prologueSql.execute(params.bindVariableEnabled)(conn)
 
       val (storage, stage) = CloudStorageOperations.createStorageClient(
         params, conn, tempStage = true, None, "load")

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -392,10 +392,11 @@ class MiscSuite01 extends FunSuite with Matchers {
     var param = Parameters.MergedParameters(sfOptions)
     // test default values
     var setString = Utils.genPrologueSql(param)
-    assert(setString.get.toString.equals("alter session set timezone = 'GMT' , " +
+    assert(setString.toString.equals("alter session set timezone = 'GMT' , " +
       "timestamp_ntz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF3', " +
       "timestamp_ltz_output_format = 'TZHTZM YYYY-MM-DD HH24:MI:SS.FF3', " +
-      "timestamp_tz_output_format = 'TZHTZM YYYY-MM-DD HH24:MI:SS.FF3' ;"))
+      "timestamp_tz_output_format = 'TZHTZM YYYY-MM-DD HH24:MI:SS.FF3' ; " +
+      "alter session set ABORT_DETACHED_QUERY=false ;"))
 
     sfOptions = Map(
       Parameters.PARAM_SF_TIMEZONE -> "UTC",
@@ -406,10 +407,11 @@ class MiscSuite01 extends FunSuite with Matchers {
     param = Parameters.MergedParameters(sfOptions)
     // test normal settings
     setString = Utils.genPrologueSql(param)
-    assert(setString.get.toString.equals("alter session set timezone = 'UTC' , " +
+    assert(setString.toString.equals("alter session set timezone = 'UTC' , " +
       "timestamp_ntz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF4', " +
       "timestamp_ltz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF5', " +
-      "timestamp_tz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6' ;"))
+      "timestamp_tz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6' ; " +
+      "alter session set ABORT_DETACHED_QUERY=false ;"))
 
     sfOptions = Map(
       Parameters.PARAM_SF_TIMEZONE -> "sf_current",
@@ -420,10 +422,11 @@ class MiscSuite01 extends FunSuite with Matchers {
     param = Parameters.MergedParameters(sfOptions)
     // test timezone is sf_current
     setString = Utils.genPrologueSql(param)
-    assert(setString.get.toString.equals("alter session set " +
+    assert(setString.toString.equals("alter session set " +
       "timestamp_ntz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF4', " +
       "timestamp_ltz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF5', " +
-      "timestamp_tz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6' ;"))
+      "timestamp_tz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6' ; " +
+      "alter session set ABORT_DETACHED_QUERY=false ;"))
 
     sfOptions = Map(
       Parameters.PARAM_SF_TIMEZONE -> "UTC",
@@ -434,9 +437,10 @@ class MiscSuite01 extends FunSuite with Matchers {
     param = Parameters.MergedParameters(sfOptions)
     // test timestamp_ltz_output_format is sf_current
     setString = Utils.genPrologueSql(param)
-    assert(setString.get.toString.equals("alter session set timezone = 'UTC' , " +
+    assert(setString.toString.equals("alter session set timezone = 'UTC' , " +
       "timestamp_ntz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF4', " +
-      "timestamp_tz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6' ;"))
+      "timestamp_tz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6' ; " +
+      "alter session set ABORT_DETACHED_QUERY=false ;"))
 
     sfOptions = Map(
       Parameters.PARAM_SF_TIMEZONE -> "sf_current",
@@ -448,8 +452,9 @@ class MiscSuite01 extends FunSuite with Matchers {
     param = Parameters.MergedParameters(sfOptions)
     // test timezone, timestamp_ntz_output_format and timestamp_tz_output_format are sf_current
     setString = Utils.genPrologueSql(param)
-    assert(setString.get.toString.equals("alter session set " +
-      "timestamp_ltz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF5' ;"))
+    assert(setString.toString.equals("alter session set " +
+      "timestamp_ltz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF5' ; " +
+      "alter session set ABORT_DETACHED_QUERY=false ;"))
 
     sfOptions = Map(
       Parameters.PARAM_SF_TIMEZONE -> "sf_current",
@@ -459,9 +464,22 @@ class MiscSuite01 extends FunSuite with Matchers {
     )
 
     param = Parameters.MergedParameters(sfOptions)
-    // test all are sf_current
+    // test all are sf_current, only session parameters query should be returned
     setString = Utils.genPrologueSql(param)
-    assert(setString.isEmpty)
+    assert(setString.toString.equals("alter session set ABORT_DETACHED_QUERY=false ;"))
+
+    sfOptions = Map(
+      Parameters.PARAM_SF_TIMEZONE -> "sf_current",
+      Parameters.PARAM_TIMESTAMP_NTZ_OUTPUT_FORMAT -> "sf_current",
+      Parameters.PARAM_TIMESTAMP_LTZ_OUTPUT_FORMAT -> "sf_current",
+      Parameters.PARAM_TIMESTAMP_TZ_OUTPUT_FORMAT -> "sf_current",
+      Parameters.PARAM_ABORT_DETACHED_QUERY_SESSION_VARIABLE -> "true"
+    )
+
+    param = Parameters.MergedParameters(sfOptions)
+    // test all are sf_current, but with abort_detached_query=true
+    setString = Utils.genPrologueSql(param)
+    assert(setString.toString.equals("alter session set ABORT_DETACHED_QUERY=true ;"))
   }
 
   test("test getQueryIDUrl") {


### PR DESCRIPTION
When customer use async mode for query execution (async mode on JDBC driver) and he has ABORT_DETACHED_QUERY parameters set to true, then long running queries (longer than 5 minutes) being cancelled.

For more details, please take a look on https://docs.snowflake.com/en/sql-reference/parameters#abort-detached-query.

The current fix is to set session parameter to override user/account level parameter setting, while we still want to allow customer to pass desired value to options of spark read.