### PR TITLE
SNOW-1291653 DIsable abort_detached_query at Session Level

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -233,6 +233,11 @@ object Parameters {
     "support_share_connection"
   )
 
+  // enable/disable ABORT_DETACHED_QUERY in the session level
+  val PARAM_ABORT_DETACHED_QUERY: String = knownParam(
+    "abort_detached_query"
+  )
+
   // preactions and postactions may affect the session level setting, so connection sharing
   // may be enabled only when the queries in preactions and postactions are in a white list.
   // force_skip_pre_post_action_check_for_session_sharing is introduced if users are sure that
@@ -718,6 +723,9 @@ object Parameters {
     }
     def supportShareConnection: Boolean = {
       isTrue(parameters.getOrElse(PARAM_SUPPORT_SHARE_CONNECTION, "true"))
+    }
+    def abortDetachedQuery: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_ABORT_DETACHED_QUERY, "false"))
     }
     def forceSkipPrePostActionsCheck: Boolean = {
       isTrue(parameters.getOrElse(

--- a/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
@@ -256,6 +256,11 @@ private[snowflake] object ServerConnection {
       }
     }
 
+    // abort_detached_query
+    conn.createStatement().execute(
+      s"alter session set ABORT_DETACHED_QUERY = ${params.abortDetachedQuery}"
+    )
+
     // Setup query result format explicitly because this option is not supported
     // to be set with JDBC properties
     if (params.supportAWSStageEndPoint) {

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -515,4 +515,12 @@ class MiscSuite01 extends FunSuite with Matchers {
     assert(queryURL.startsWith("Cannot generate queryID URL for https://unrecognized_url"))
   }
 
+  test("abort_detached_query") {
+    val param = Parameters.MergedParameters(Map.empty)
+    assert(!param.abortDetachedQuery)
+
+    val param1 = Parameters.MergedParameters(Map("abort_detached_query" -> "true"))
+    assert(param1.abortDetachedQuery)
+  }
+
 }


### PR DESCRIPTION
Disable `ABORT_DETACHED_QUERY` at session level by default, to fix `async query canceled after 5 mins` issue.