### PR TITLE
SNOW-1515815 Remove the Requirement of SFUSER Parameter when using OAUTH

### DIFF
--- a/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/TestUtils.scala
+++ b/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/TestUtils.scala
@@ -175,7 +175,10 @@ object TestUtils {
     // Obligatory properties
     jdbcProperties.put("db", params.sfDatabase)
     jdbcProperties.put("schema", params.sfSchema) // Has a default
-    jdbcProperties.put("user", params.sfUser)
+    if (params.sfUser != null) {
+      // user is optional when using Oauth token
+      jdbcProperties.put("account", params.sfAccount.get)
+    }
 
     params.privateKey match {
       case Some(privateKey) =>

--- a/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/TestUtils.scala
+++ b/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/TestUtils.scala
@@ -177,7 +177,7 @@ object TestUtils {
     jdbcProperties.put("schema", params.sfSchema) // Has a default
     if (params.sfUser != null) {
       // user is optional when using Oauth token
-      jdbcProperties.put("account", params.sfAccount.get)
+      jdbcProperties.put("user", params.sfUser)
     }
 
     params.privateKey match {

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -321,12 +321,12 @@ object Parameters {
           "' parameter, e.g. 'accountname.snowflakecomputing.com:443'"
       )
     }
-    if (!userParameters.contains(PARAM_SF_USER)) {
+    val tokenVal = userParameters.get(PARAM_OAUTH_TOKEN)
+    if ((!userParameters.contains(PARAM_SF_USER)) &&  tokenVal.isEmpty) {
       throw new IllegalArgumentException(
         "A snowflake user must be provided with '" + PARAM_SF_USER + "' parameter, e.g. 'user1'"
       )
     }
-    val tokenVal = userParameters.get(PARAM_OAUTH_TOKEN)
     if ((!userParameters.contains(PARAM_SF_PASSWORD)) &&
       (!userParameters.contains(PARAM_PEM_PRIVATE_KEY)) &&
       //  if OAuth token not provided
@@ -621,7 +621,8 @@ object Parameters {
     /**
       * Snowflake user
       */
-    def sfUser: String = parameters(PARAM_SF_USER)
+    def sfUser: String = parameters.getOrElse(PARAM_SF_USER, null)
+
 
     /**
       * Snowflake password

--- a/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
@@ -159,10 +159,8 @@ private[snowflake] object ServerConnection {
     jdbcProperties.put("schema", params.sfSchema) // Has a default
     if (params.sfUser != null) {
       // user is optional when using Oauth token
-      jdbcProperties.put("account", params.sfAccount.get)
+      jdbcProperties.put("user", params.sfUser)
     }
-    jdbcProperties.put("user", params.sfUser)
-
     params.privateKey match {
       case Some(privateKey) =>
         jdbcProperties.put("privateKey", privateKey)

--- a/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
@@ -157,6 +157,10 @@ private[snowflake] object ServerConnection {
     // Obligatory properties
     jdbcProperties.put("db", params.sfDatabase)
     jdbcProperties.put("schema", params.sfSchema) // Has a default
+    if (params.sfUser != null) {
+      // user is optional when using Oauth token
+      jdbcProperties.put("account", params.sfAccount.get)
+    }
     jdbcProperties.put("user", params.sfUser)
 
     params.privateKey match {

--- a/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/ParametersSuite.scala
@@ -108,6 +108,7 @@ class ParametersSuite extends FunSuite with Matchers {
     params += "sfauthenticator" -> "oauth"
     params += "sftoken" -> "mytoken"
     params.remove("sfpassword")
+    params.remove("sfuser")
     val mergedParams = Parameters.mergeParameters(params.toMap)
     mergedParams.sfAuthenticator shouldBe Some("oauth")
     mergedParams.sfToken shouldBe Some("mytoken")


### PR DESCRIPTION
When `sftoken` is not empty, `sfuser` is optional.