### PR TITLE
Support trailing comments in passed SQL queries

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -57,7 +57,7 @@ private[snowflake] case class SnowflakeRelation(
   override lazy val schema: StructType = {
     userSchema.getOrElse {
       val tableNameOrSubquery =
-        params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
+        params.query.map(q => s"(\n $q \n)").orElse(params.table.map(_.toString)).get
       val conn = jdbcWrapper.getConnector(params)
       try {
         jdbcWrapper.resolveTable(conn, tableNameOrSubquery, params)
@@ -344,7 +344,7 @@ private[snowflake] case class SnowflakeRelation(
     val tableNameOrSubquery: StatementElement =
       params.table
         .map(_.toStatement)
-        .getOrElse(ConstantString("(" + params.query.get + ")"))
+        .getOrElse(ConstantString("(\n" + params.query.get + "\n)"))
     ConstantString("SELECT") + columnList + "FROM" + tableNameOrSubquery + whereClause
   }
 }

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
@@ -148,7 +148,7 @@ private[snowflake] object StageReader {
                  |    NULL_IF= ()
                  |  )
                  |  """.stripMargin) !,
-            ConstantString("FROM (") + statement + ")"
+            ConstantString("FROM (\n") + statement + "\n)"
           )
         case SupportedFormat.JSON =>
           (
@@ -158,7 +158,7 @@ private[snowflake] object StageReader {
                  |    COMPRESSION='$compression'
                  |)
                  |""".stripMargin) !,
-            ConstantString("FROM (SELECT object_construct(*) FROM (") + statement + "))"
+            ConstantString("FROM (SELECT object_construct(*) FROM (\n") + statement + "\n))"
           )
       }
 


### PR DESCRIPTION
To support trailing comments, particularly the inline types with -- or //, the query wrapping performed
in the connector needs to ensure the query is placed into a new line of its own

Otherwise, passing such an inline comment will break the Snowflake SQL syntax.

Attempting any of the following, for example, fails today:

```
spark.sql("select * from table -- trailing comment").collect()
spark.read.[…].option("query", "select * from table -- trailing comment").load()
```

The failure occurs due to Spark wrapping around the query and executing a resulting invalid syntax:

```
select col from (select * from table -- trailing comment)
```

The change made here works by adjusting such wrapping to always, safely place provided statements into their own line:

```
select col from (
select * from table -- trailing comment
)
```

This allows for a valid syntax to be used despite users accidentally placing trailing comments at the end.

The tests added fail without the fixes added (tested via `sbt test it:test`).