### PR TITLE
SNOW-2207811: Fix tmp aws credentials for external S3 bucket

### DIFF
--- a/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
@@ -408,7 +408,7 @@ class StageSuite extends IntegrationSuiteBase {
   private val MAN_TEST_AWS_TEMPDIR = "MAN_TEST_AWS_TEMPDIR"
   private val MAN_TEST_AWS_ACCESS_KEY = "MAN_TEST_AWS_ACCESS_KEY"
   private val MAN_TEST_AWS_SECRET_KEY = "MAN_TEST_AWS_SECRET_KEY"
-  ignore ("manual test with s3 external stage") {
+  test ("manual test with s3 external stage") {
     if (System.getenv(MAN_TEST_AWS_TEMPDIR) != null &&
       System.getenv(MAN_TEST_AWS_ACCESS_KEY) != null &&
       System.getenv(MAN_TEST_AWS_SECRET_KEY) != null) {
@@ -419,6 +419,55 @@ class StageSuite extends IntegrationSuiteBase {
       sfOptionsNoTable += ("tempdir" -> System.getenv(MAN_TEST_AWS_TEMPDIR))
       sfOptionsNoTable += ("awsaccesskey" -> System.getenv(MAN_TEST_AWS_ACCESS_KEY))
       sfOptionsNoTable += ("awssecretkey" -> System.getenv(MAN_TEST_AWS_SECRET_KEY))
+
+      val df = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(sfOptionsNoTable)
+        .option("dbtable", test_table_large_result)
+        .load()
+
+      df.write
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(sfOptionsNoTable)
+        .option("dbtable", test_table_write)
+        .option("truncate_table", "off")
+        .option("usestagingtable", "on")
+        .option("purge", "true")
+        .mode(SaveMode.Overwrite)
+        .save()
+
+      val dfTarget = sparkSession.read
+        .format(SNOWFLAKE_SOURCE_NAME)
+        .options(sfOptionsNoTable)
+        .option("dbtable", test_table_write)
+        .load()
+      assert(dfTarget.count() == LARGE_TABLE_ROW_COUNT)
+
+      Utils.runQuery(
+        sfOptionsNoTable,
+        s"drop table if exists $test_table_large_result"
+      )
+    }
+  }
+
+  // Manually test AWS external stage
+  // You need to set below 3 environment variables and MAN_TEST_AWS_TEMPDIR
+  private val MAN_TEST_AWS_TMP_ACCESS_KEY = "MAN_TEST_AWS_TMP_ACCESS_KEY"
+  private val MAN_TEST_AWS_TMP_SECRET_KEY = "MAN_TEST_AWS_TMP_SECRET_KEY"
+  private val MAN_TEST_AWS_TMP_SESSION_TOKEN = "MAN_TEST_AWS_TMP_SESSION_TOKEN"
+  test ("manual test with s3 external stage using temporary credentials") {
+    if (System.getenv(MAN_TEST_AWS_TEMPDIR) != null &&
+      System.getenv(MAN_TEST_AWS_TMP_ACCESS_KEY) != null &&
+      System.getenv(MAN_TEST_AWS_TMP_SECRET_KEY) != null &&
+      System.getenv(MAN_TEST_AWS_TMP_SESSION_TOKEN) != null) {
+      var sfOptionsNoTable = connectorOptionsNoTable
+      setupLargeResultTable(sfOptionsNoTable)
+
+      // Set AWS external stage options
+      sfOptionsNoTable += ("tempdir" -> System.getenv(MAN_TEST_AWS_TEMPDIR))
+      sfOptionsNoTable += ("temporary_aws_access_key_id" -> System.getenv(MAN_TEST_AWS_TMP_ACCESS_KEY))
+      sfOptionsNoTable += ("temporary_aws_secret_access_key" -> System.getenv(MAN_TEST_AWS_TMP_SECRET_KEY))
+      sfOptionsNoTable += ("temporary_aws_session_token" -> System.getenv(MAN_TEST_AWS_TMP_SESSION_TOKEN))
 
       val df = sparkSession.read
         .format(SNOWFLAKE_SOURCE_NAME)

--- a/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
@@ -408,7 +408,7 @@ class StageSuite extends IntegrationSuiteBase {
   private val MAN_TEST_AWS_TEMPDIR = "MAN_TEST_AWS_TEMPDIR"
   private val MAN_TEST_AWS_ACCESS_KEY = "MAN_TEST_AWS_ACCESS_KEY"
   private val MAN_TEST_AWS_SECRET_KEY = "MAN_TEST_AWS_SECRET_KEY"
-  test ("manual test with s3 external stage") {
+  ignore ("manual test with s3 external stage") {
     if (System.getenv(MAN_TEST_AWS_TEMPDIR) != null &&
       System.getenv(MAN_TEST_AWS_ACCESS_KEY) != null &&
       System.getenv(MAN_TEST_AWS_SECRET_KEY) != null) {
@@ -455,7 +455,7 @@ class StageSuite extends IntegrationSuiteBase {
   private val MAN_TEST_AWS_TMP_ACCESS_KEY = "MAN_TEST_AWS_TMP_ACCESS_KEY"
   private val MAN_TEST_AWS_TMP_SECRET_KEY = "MAN_TEST_AWS_TMP_SECRET_KEY"
   private val MAN_TEST_AWS_TMP_SESSION_TOKEN = "MAN_TEST_AWS_TMP_SESSION_TOKEN"
-  test ("manual test with s3 external stage using temporary credentials") {
+  ignore ("manual test with s3 external stage using temporary credentials") {
     if (System.getenv(MAN_TEST_AWS_TEMPDIR) != null &&
       System.getenv(MAN_TEST_AWS_TMP_ACCESS_KEY) != null &&
       System.getenv(MAN_TEST_AWS_TMP_SECRET_KEY) != null &&

--- a/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
@@ -450,7 +450,7 @@ class StageSuite extends IntegrationSuiteBase {
     }
   }
 
-  // Manually test AWS external stage
+  // Manually test AWS external stage with temporary aws credentials
   // You need to set below 3 environment variables and MAN_TEST_AWS_TEMPDIR
   private val MAN_TEST_AWS_TMP_ACCESS_KEY = "MAN_TEST_AWS_TMP_ACCESS_KEY"
   private val MAN_TEST_AWS_TMP_SECRET_KEY = "MAN_TEST_AWS_TMP_SECRET_KEY"

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -317,7 +317,6 @@ object CloudStorageOperations {
             }
             (creds.getAWSAccessKeyId, creds.getAWSSecretKey, token)
           case None =>
-            // TODO: fall back to creds.getAWSAccessKeyId, creds.getAWSSecretKey
             // Fall back to direct credential parameters
             (param.awsAccessKey.orNull, param.awsSecretKey.orNull, None)
         }

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -317,6 +317,7 @@ object CloudStorageOperations {
             }
             (creds.getAWSAccessKeyId, creds.getAWSSecretKey, token)
           case None =>
+            // TODO: fall back to creds.getAWSAccessKeyId, creds.getAWSSecretKey
             // Fall back to direct credential parameters
             (param.awsAccessKey.orNull, param.awsSecretKey.orNull, None)
         }

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -306,15 +306,38 @@ object CloudStorageOperations {
         )
 
       case s3_url(bucket, prefix) =>
-        require(param.awsAccessKey.isDefined, "missing aws access key")
-        require(param.awsSecretKey.isDefined, "missing aws secret key")
+        // Try to get credentials from temporaryAWSCredentials first, then fall back to direct credentials
+        val (accessKey, secretKey, sessionToken) = param.temporaryAWSCredentials match {
+          case Some(creds) =>
+            // Extract credentials from temporaryAWSCredentials object
+            val token = creds match {
+              case sessionCreds: net.snowflake.client.jdbc.internal.amazonaws.auth.AWSSessionCredentials =>
+                Some(sessionCreds.getSessionToken)
+              case _ => None
+            }
+            (creds.getAWSAccessKeyId, creds.getAWSSecretKey, token)
+          case None =>
+            // Fall back to direct credential parameters
+            (param.awsAccessKey.orNull, param.awsSecretKey.orNull, None)
+        }
+
+        // Validate that we have the required credentials
+        require(accessKey != null, "missing aws access key")
+        require(secretKey != null, "missing aws secret key")
+
+        // Build SQL statement with session token if available
+        val credentialsClause = sessionToken match {
+          case Some(token) =>
+            s"(aws_key_id='$accessKey' aws_secret_key='$secretKey' aws_token='$token')"
+          case None =>
+            s"(aws_key_id='$accessKey' aws_secret_key='$secretKey')"
+        }
 
         val sql =
           s"""
              |create or replace ${if (tempStage) "temporary" else ""} stage $stageName
              |url = 's3://$bucket/$prefix'
-             |credentials =
-             |(aws_key_id='${param.awsAccessKey.get}' aws_secret_key='${param.awsSecretKey.get}')
+             |credentials = $credentialsClause
          """.stripMargin
 
         DefaultJDBCWrapper.executeQueryInterruptibly(conn, sql)
@@ -323,8 +346,8 @@ object CloudStorageOperations {
           ExternalS3Storage(
             param = param,
             bucketName = bucket,
-            awsId = param.awsAccessKey.get,
-            awsKey = param.awsSecretKey.get,
+            awsId = accessKey,
+            awsKey = secretKey,
             param.expectedPartitionCount,
             pref = prefix,
             connection = conn,

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -349,6 +349,7 @@ object CloudStorageOperations {
             awsId = accessKey,
             awsKey = secretKey,
             param.expectedPartitionCount,
+            awsToken = sessionToken,
             pref = prefix,
             connection = conn,
             // For S3 external stage, it doesn't use region name in URL


### PR DESCRIPTION
SNOW-2207811

### Bug
When using external S3 bucket, the temp aws credentials are not passed correctly.

### Test
Manually tested the `test ("manual test with s3 external stage using temporary credentials")`