### PR TITLE
Prevent partial data upload by skipping stream close on failure

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -739,7 +739,8 @@ sealed trait CloudStorage {
         }
         success = true
       } finally {
-        if (success) {
+        val isInterrupted = TaskContext.get() != null && TaskContext.get().isInterrupted()
+        if (success && !isInterrupted) {
           if (storageInfo.isDefined) {
             uploadStream.close()
           } else {
@@ -770,6 +771,10 @@ sealed trait CloudStorage {
                  | ${Utils.getTimeString(endTime - startTime)}
                  |""".stripMargin.filter(_ >= ' ')
           }
+        } else {
+          CloudStorageOperations.log.warn(
+            s"Discarding partial file $fileName. success=$success, isInterrupted=$isInterrupted"
+          )
         }
       }
     } else {

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -708,6 +708,7 @@ sealed trait CloudStorage {
       } else {
         new ByteArrayOutputStream(4 * 1024 * 1024)
       }
+      var success = false
       try {
         format match {
           case SupportedFormat.PARQUET =>
@@ -736,36 +737,39 @@ sealed trait CloudStorage {
               dataSize += (oneRow.size + 1)
             }
         }
+        success = true
       } finally {
-        if (storageInfo.isDefined) {
-          uploadStream.close()
-        } else {
-          val data = uploadStream.asInstanceOf[ByteArrayOutputStream].toByteArray
-          dataSize = data.size
-          uploadStream.close()
-          // Set up proxy info if it is configured.
-          val proxyProperties = new Properties()
-          proxyInfo match {
-            case Some(proxyInfoValue) =>
-              proxyInfoValue.setProxyForJDBC(proxyProperties)
-            case None =>
-          }
+        if (success) {
+          if (storageInfo.isDefined) {
+            uploadStream.close()
+          } else {
+            val data = uploadStream.asInstanceOf[ByteArrayOutputStream].toByteArray
+            dataSize = data.size
+            uploadStream.close()
+            // Set up proxy info if it is configured.
+            val proxyProperties = new Properties()
+            proxyInfo match {
+              case Some(proxyInfoValue) =>
+                proxyInfoValue.setProxyForJDBC(proxyProperties)
+              case None =>
+            }
 
-          val inStream = new ByteArrayInputStream(data)
-          SnowflakeFileTransferAgent.uploadWithoutConnection(
-            SnowflakeFileTransferConfig.Builder.newInstance()
-              .setSnowflakeFileTransferMetadata(fileTransferMetadata.get)
-              .setUploadStream(inStream)
-              .setRequireCompress(false)
-              .setDestFileName(fileName)
-              .setOcspMode(OCSPMode.FAIL_OPEN)
-              .setProxyProperties(proxyProperties)
-              .build())
-          val endTime = System.currentTimeMillis()
-          processTimeInfo =
-            s"""read_and_upload_time:
-               | ${Utils.getTimeString(endTime - startTime)}
-               |""".stripMargin.filter(_ >= ' ')
+            val inStream = new ByteArrayInputStream(data)
+            SnowflakeFileTransferAgent.uploadWithoutConnection(
+              SnowflakeFileTransferConfig.Builder.newInstance()
+                .setSnowflakeFileTransferMetadata(fileTransferMetadata.get)
+                .setUploadStream(inStream)
+                .setRequireCompress(false)
+                .setDestFileName(fileName)
+                .setOcspMode(OCSPMode.FAIL_OPEN)
+                .setProxyProperties(proxyProperties)
+                .build())
+            val endTime = System.currentTimeMillis()
+            processTimeInfo =
+              s"""read_and_upload_time:
+                 | ${Utils.getTimeString(endTime - startTime)}
+                 |""".stripMargin.filter(_ >= ' ')
+          }
         }
       }
     } else {


### PR DESCRIPTION
Fix a critical bug causing silent data loss when writing to Snowflake with Spark Speculation enabled (`spark.speculation=true`). 
Currently, killed speculative tasks can accidentally overwrite the complete files produced by successful tasks. Because the truncated files are still valid GZIP/CSV files, Snowflake's `COPY INTO` command processes them successfully but ends up loading fewer records than actual.

This issue occurs because of the try-finally block in `doUploadPartition()`.
https://github.com/snowflakedb/spark-snowflake/blob/36fb1aff3427ae4f4c6684d10d273d91c20b806f/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala#L739-L742
In case of speculative task kill, Spark interrupts the thread. However, there are chances that this interrupt gets unset by downstream operators (like reading ops).

When execution jumps to the finally block, `uploadStream.close()` gets called. Because the interrupt flag is now clear, the AWS/Cloud SDK doesn't realize the task was aborted and happily commits the partial multipart upload, silently overwriting the successful task's file.

In one of our production job, we caught a killed task overwriting a successful task's output:
```
# Task that succeeded
26/04/13 08:24:10 INFO CloudStorageOperations$: Spark Connector Worker: Finish uploading file nTCVQj9U0c/35.CSV.gz without AWS multiple parts API because the data size is less than the buffer size: bufferSize=8.00 MB compressedSize=725.25 KB

# Speculative task that was killed halfway, but committed
26/04/13 08:24:13 INFO CloudStorageOperations$: Spark Connector Worker: Finish uploading file nTCVQj9U0c/35.CSV.gz without AWS multiple parts API because the data size is less than the buffer size: bufferSize=8.00 MB compressedSize=294.44 KB
# There is recognized, but file is already committed
26/04/13 08:24:13 WARN CloudStorageOperations$: Spark Connector Worker: hit upload error: partition ID:35 35.CSV.gz attemptNumber=1 Skip exponential backoff sleep because use_exponential_backoff is 'off'. Please enable it if necessary, for example, cloud service throttling issues happen.
```
### The Fix
Simplest fix is to add a success boolean flag inside `doUploadPartition()` that is only set to true when the record iteration fully completes. The finally block now checks this flag and skips `uploadStream.close()` if the task was aborted, ensuring we abandon the partial file rather than committing it. We also check `TaskContext#isInterrupted()` as second line of defense since It is always set before killing the task. 

Based on the implementation of output stream, this could lead to resource leak, but current object storage implementations should not have any issue.