### PR TITLE
NOSNOW: Prevent silent data loss when speculative tasks are killed during stage upload

### DIFF
--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -739,7 +739,8 @@ sealed trait CloudStorage {
         }
         success = true
       } finally {
-        if (success) {
+        val isInterrupted = TaskContext.get() != null && TaskContext.get().isInterrupted()
+        if (success && !isInterrupted) {
           if (storageInfo.isDefined) {
             uploadStream.close()
           } else {
@@ -770,6 +771,10 @@ sealed trait CloudStorage {
                  | ${Utils.getTimeString(endTime - startTime)}
                  |""".stripMargin.filter(_ >= ' ')
           }
+        } else {
+          CloudStorageOperations.log.warn(
+            s"Discarding partial file $fileName. success=$success, isInterrupted=$isInterrupted"
+          )
         }
       }
     } else {

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -708,6 +708,7 @@ sealed trait CloudStorage {
       } else {
         new ByteArrayOutputStream(4 * 1024 * 1024)
       }
+      var success = false
       try {
         format match {
           case SupportedFormat.PARQUET =>
@@ -736,36 +737,39 @@ sealed trait CloudStorage {
               dataSize += (oneRow.size + 1)
             }
         }
+        success = true
       } finally {
-        if (storageInfo.isDefined) {
-          uploadStream.close()
-        } else {
-          val data = uploadStream.asInstanceOf[ByteArrayOutputStream].toByteArray
-          dataSize = data.size
-          uploadStream.close()
-          // Set up proxy info if it is configured.
-          val proxyProperties = new Properties()
-          proxyInfo match {
-            case Some(proxyInfoValue) =>
-              proxyInfoValue.setProxyForJDBC(proxyProperties)
-            case None =>
-          }
+        if (success) {
+          if (storageInfo.isDefined) {
+            uploadStream.close()
+          } else {
+            val data = uploadStream.asInstanceOf[ByteArrayOutputStream].toByteArray
+            dataSize = data.size
+            uploadStream.close()
+            // Set up proxy info if it is configured.
+            val proxyProperties = new Properties()
+            proxyInfo match {
+              case Some(proxyInfoValue) =>
+                proxyInfoValue.setProxyForJDBC(proxyProperties)
+              case None =>
+            }
 
-          val inStream = new ByteArrayInputStream(data)
-          SnowflakeFileTransferAgent.uploadWithoutConnection(
-            SnowflakeFileTransferConfig.Builder.newInstance()
-              .setSnowflakeFileTransferMetadata(fileTransferMetadata.get)
-              .setUploadStream(inStream)
-              .setRequireCompress(false)
-              .setDestFileName(fileName)
-              .setOcspMode(OCSPMode.FAIL_OPEN)
-              .setProxyProperties(proxyProperties)
-              .build())
-          val endTime = System.currentTimeMillis()
-          processTimeInfo =
-            s"""read_and_upload_time:
-               | ${Utils.getTimeString(endTime - startTime)}
-               |""".stripMargin.filter(_ >= ' ')
+            val inStream = new ByteArrayInputStream(data)
+            SnowflakeFileTransferAgent.uploadWithoutConnection(
+              SnowflakeFileTransferConfig.Builder.newInstance()
+                .setSnowflakeFileTransferMetadata(fileTransferMetadata.get)
+                .setUploadStream(inStream)
+                .setRequireCompress(false)
+                .setDestFileName(fileName)
+                .setOcspMode(OCSPMode.FAIL_OPEN)
+                .setProxyProperties(proxyProperties)
+                .build())
+            val endTime = System.currentTimeMillis()
+            processTimeInfo =
+              s"""read_and_upload_time:
+                 | ${Utils.getTimeString(endTime - startTime)}
+                 |""".stripMargin.filter(_ >= ' ')
+          }
         }
       }
     } else {

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -775,6 +775,22 @@ sealed trait CloudStorage {
           CloudStorageOperations.log.warn(
             s"Discarding partial file $fileName. success=$success, isInterrupted=$isInterrupted"
           )
+          // Actively abandon any work the upload stream has already done.
+          // Critically, we must NOT call close() here — for an
+          // S3UploadOutputStream that would commit the buffered partial
+          // data via putObject (single-shot path) or completeMultipartUpload
+          // (multipart path), overwriting a sibling task's successful file.
+          // Instead, abort the multipart upload (if one was initiated) so
+          // we don't leak in-progress parts in the bucket.
+          uploadStream match {
+            case s3: S3UploadOutputStream => s3.abort()
+            case _ =>
+              // For the anonymous OutputStream wrappers used by other
+              // storage backends, the data is held only in an in-memory
+              // ByteArrayOutputStream until close(); skipping close() means
+              // the buffer is simply discarded. No cloud-side cleanup
+              // needed.
+          }
         }
       }
     } else {
@@ -2193,5 +2209,39 @@ private[io] class S3UploadOutputStream(s3Client: AmazonS3,
     if (dataSizeInBuffer > 0) {
       uploadDataChunk(isLastChunk = true)
     }
+  }
+
+  // Abandon any in-progress multipart upload without committing it.
+  //
+  // Used when the upload is aborted (e.g. speculative task killed). Avoids
+  // calling close() — which would commit the partial data and overwrite a
+  // sibling task's successful object — and explicitly aborts any S3 multipart
+  // upload that was already initiated, so we don't leak parts.
+  //
+  // Safe to call multiple times. Errors are logged and swallowed; this is
+  // expected to run from a finally block where we don't want a cleanup
+  // failure to mask the original cause.
+  private[io] def abort(): Unit = {
+    if (useMultipleBlockUpload) {
+      try {
+        s3Client.abortMultipartUpload(
+          new AbortMultipartUploadRequest(
+            bucketName, keyName, initResponse.getUploadId))
+        CloudStorageOperations.log.info(
+          s"""${SnowflakeResultSetRDD.WORKER_LOG_PREFIX}:
+             | Aborted in-progress multipart upload for $file
+             | uploadId=${initResponse.getUploadId}
+             |""".stripMargin.filter(_ >= ' '))
+      } catch {
+        case th: Throwable =>
+          CloudStorageOperations.log.warn(
+            s"""${SnowflakeResultSetRDD.WORKER_LOG_PREFIX}:
+               | Failed to abort multipart upload for $file:
+               | ${th.getMessage}
+               |""".stripMargin.filter(_ >= ' '))
+      }
+    }
+    try byteArrayOutputStream.close()
+    catch { case _: Throwable => () }
   }
 }

--- a/src/test/scala/net/snowflake/spark/snowflake/io/S3UploadOutputStreamAbortSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/io/S3UploadOutputStreamAbortSuite.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2015-2026 Snowflake Computing
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.snowflake.spark.snowflake.io
+
+import net.snowflake.client.jdbc.internal.amazonaws.services.s3.AbstractAmazonS3
+import net.snowflake.client.jdbc.internal.amazonaws.services.s3.model.{
+  AbortMultipartUploadRequest,
+  CompleteMultipartUploadRequest,
+  CompleteMultipartUploadResult,
+  InitiateMultipartUploadRequest,
+  InitiateMultipartUploadResult,
+  ObjectMetadata,
+  PutObjectResult,
+  UploadPartRequest,
+  UploadPartResult
+}
+import org.scalatest.FunSuite
+
+import scala.collection.mutable
+
+/**
+ * Unit tests for `S3UploadOutputStream#abort()`, the cleanup path used when
+ * a Spark task is interrupted (e.g. speculative-task kill) and we must
+ * abandon the partial upload instead of committing it.
+ *
+ * Background: under Spark speculation a killed task could overwrite a
+ * successful task's staged file because `close()` was called unconditionally
+ * in the `finally` block of `doUploadPartition`, committing a partial
+ * multipart upload (or single-shot putObject) over the good object. The fix
+ * skips `close()` and calls `abort()` instead so the partial upload is
+ * abandoned.
+ *
+ * The invariants exercised here are:
+ *   1. abort() must NEVER call any S3 API that commits data, regardless
+ *      of whether multipart was initiated.
+ *   2. If multipart WAS initiated, abort() must explicitly issue
+ *      AbortMultipartUpload so already-uploaded parts don't leak in S3.
+ *   3. abort() must swallow cleanup failures (it runs in a finally
+ *      block).
+ */
+class S3UploadOutputStreamAbortSuite extends FunSuite {
+
+  private val storageInfo = Map(
+    StorageInfo.BUCKET_NAME -> "test_bucket",
+    StorageInfo.PREFIX -> "test_prefix/"
+  )
+  private val fileName = "35.CSV.gz"
+
+  /**
+   * Records every call we care about. Inherits from `AbstractAmazonS3`,
+   * which throws `UnsupportedOperationException` for every method, so any
+   * unexpected use of the S3 client surfaces as a test failure rather than
+   * silently no-opping.
+   */
+  private class RecordingS3 extends AbstractAmazonS3 {
+    val initiate = mutable.ArrayBuffer[InitiateMultipartUploadRequest]()
+    val uploadPart = mutable.ArrayBuffer[UploadPartRequest]()
+    val complete = mutable.ArrayBuffer[CompleteMultipartUploadRequest]()
+    val abort = mutable.ArrayBuffer[AbortMultipartUploadRequest]()
+    val putObjectKeys = mutable.ArrayBuffer[(String, String)]()
+    var uploadId: String = "test-upload-id"
+    var abortShouldThrow: Throwable = null
+
+    override def initiateMultipartUpload(
+      req: InitiateMultipartUploadRequest
+    ): InitiateMultipartUploadResult = synchronized {
+      initiate += req
+      val r = new InitiateMultipartUploadResult()
+      r.setUploadId(uploadId)
+      r
+    }
+
+    override def uploadPart(
+      req: UploadPartRequest
+    ): UploadPartResult = synchronized {
+      uploadPart += req
+      val r = new UploadPartResult()
+      r.setETag(s"etag-${uploadPart.size}")
+      r.setPartNumber(req.getPartNumber)
+      r
+    }
+
+    override def completeMultipartUpload(
+      req: CompleteMultipartUploadRequest
+    ): CompleteMultipartUploadResult = synchronized {
+      complete += req
+      new CompleteMultipartUploadResult()
+    }
+
+    override def abortMultipartUpload(
+      req: AbortMultipartUploadRequest
+    ): Unit = synchronized {
+      abort += req
+      if (abortShouldThrow != null) throw abortShouldThrow
+    }
+
+    override def putObject(
+      bucket: String,
+      key: String,
+      input: java.io.InputStream,
+      meta: ObjectMetadata
+    ): PutObjectResult = synchronized {
+      putObjectKeys += ((bucket, key))
+      new PutObjectResult()
+    }
+  }
+
+  private def assertNoCommits(s3: RecordingS3): Unit = {
+    assert(s3.putObjectKeys.isEmpty, "putObject must not be called")
+    assert(s3.complete.isEmpty, "completeMultipartUpload must not be called")
+  }
+
+  test("abort() commits nothing when no data was written") {
+    val s3 = new RecordingS3
+    val stream = new S3UploadOutputStream(
+      s3, new ObjectMetadata(), storageInfo, 1024, fileName)
+
+    stream.abort()
+
+    assertNoCommits(s3)
+    assert(s3.initiate.isEmpty,
+      "no multipart upload should have been initiated")
+    assert(s3.abort.isEmpty,
+      "no multipart upload to abort if none was initiated")
+  }
+
+  test("abort() commits nothing when data fits in single chunk " +
+    "(multipart never initiated)") {
+    val s3 = new RecordingS3
+    val bufferSize = 1024
+    val stream = new S3UploadOutputStream(
+      s3, new ObjectMetadata(), storageInfo, bufferSize, fileName)
+
+    // Strictly less than bufferSize: this is the single-shot putObject
+    // path. close() would have called putObject; abort() must not.
+    for (i <- 1 to 100) stream.write(i)
+
+    stream.abort()
+
+    assertNoCommits(s3)
+    assert(s3.initiate.isEmpty,
+      "no multipart upload should have been initiated")
+    assert(s3.abort.isEmpty,
+      "no multipart upload to abort if none was initiated")
+  }
+
+  test("abort() aborts the in-flight multipart upload after parts uploaded") {
+    val s3 = new RecordingS3
+    s3.uploadId = "test-upload-id-abc123"
+    val bufferSize = 64
+    val stream = new S3UploadOutputStream(
+      s3, new ObjectMetadata(), storageInfo, bufferSize, fileName)
+
+    // Write bufferSize+1 bytes via write(int) so the (bufferSize+1)th
+    // call triggers uploadDataChunk(false) -> doUploadOnePart(), which
+    // initiates the multipart upload and uploads part 1.
+    for (i <- 1 to bufferSize + 1) stream.write(i)
+
+    // Sanity: multipart was initiated and one part was uploaded.
+    assert(s3.initiate.size == 1, "multipart upload should be initiated once")
+    assert(s3.uploadPart.size == 1, "exactly one part should be uploaded")
+
+    stream.abort()
+
+    // The multipart upload must be explicitly aborted exactly once,
+    // with the correct (bucket, key, uploadId).
+    assert(s3.abort.size == 1, "abortMultipartUpload should be called once")
+    val req = s3.abort.head
+    assert(req.getUploadId == s3.uploadId,
+      s"unexpected uploadId: ${req.getUploadId}")
+    assert(req.getBucketName == "test_bucket",
+      s"unexpected bucket: ${req.getBucketName}")
+    assert(req.getKey == "test_prefix/" + fileName,
+      s"unexpected key: ${req.getKey}")
+
+    // And it must NOT be committed - this is the regression guard.
+    assertNoCommits(s3)
+  }
+
+  test("abort() swallows S3 abort failures (runs in a finally block)") {
+    val s3 = new RecordingS3
+    s3.abortShouldThrow = new RuntimeException("simulated S3 abort failure")
+    val bufferSize = 64
+    val stream = new S3UploadOutputStream(
+      s3, new ObjectMetadata(), storageInfo, bufferSize, "f.gz")
+
+    for (i <- 1 to bufferSize + 1) stream.write(i)
+
+    // Must not propagate. If this throws, the original cause of the
+    // abort (e.g. speculative-task kill) would be masked by a cleanup
+    // failure, which is exactly what the production try/finally is
+    // trying to avoid.
+    stream.abort()
+
+    // We did still attempt the abort.
+    assert(s3.abort.size == 1, "abort attempt should still have been made")
+  }
+}


### PR DESCRIPTION
## Summary
Under `spark.speculation=true`, a killed speculative task could silently
overwrite a successful sibling task's staged file. The truncated file is
still a valid GZIP/CSV, so `COPY INTO` completes without error and the
table ends up with fewer rows than the source — no exception, no log
warning visible on the driver. A user reported 100K+ rows lost in a
single job.

Root cause is in `CloudStorageOperations.doUploadPartition`: when Spark
interrupts a task and the `Thread.interrupted` flag has been cleared by
an intervening I/O handler, the unconditional `uploadStream.close()` in
the `finally` block still runs and commits the partial data via
`putObject` (single-shot path) or `completeMultipartUpload` (multipart
path), overwriting the good object that another attempt of the same
partition already wrote.

## Changes
1. **Skip `close()` on the failure path.** A `success` flag plus
   `TaskContext.isInterrupted()` guard the commit. If either signals
   trouble, the partial upload is abandoned.
2. **Abort multipart uploads explicitly.** For partitions large enough
   to trigger `S3UploadOutputStream`'s multipart path, parts have already
   been uploaded by the time the kill is observed. Skipping `close()`
   alone would leak the in-progress multipart upload (cost until the
   bucket's `AbortIncompleteMultipartUpload` lifecycle rule, if any,
   cleans them up). New `S3UploadOutputStream.abort()` issues
   `AbortMultipartUploadRequest` explicitly and is wired into the
   discard branch.
3. **Unit tests.** `S3UploadOutputStreamAbortSuite` exercises four
   `abort()` invariants directly against `AbstractAmazonS3`: no commit
   pre-write, no commit in the single-shot path, explicit
   `AbortMultipartUpload` (and no commit) when parts were already
   uploaded, and cleanup-failure swallowing.

## Credit
Root-cause analysis and the initial `success` flag + `TaskContext.isInterrupted()`
fix are by @BOOTMGR in #648. We're landing the work here so we can also
add the multipart-abort path and unit-test coverage. Closes #648.

Co-Authored-By: Harsh Panchal <panchal.harsh18@gmail.com>