### PR TITLE
NOSNOW: Upgrade Snowflake JDBC driver to 4.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@
 import java.io.File
 
 import scala.util.Properties
+import scala.xml.{Elem, Node => XmlNode, NodeSeq => XmlNodeSeq}
+import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 val sparkVersion = settingKey[String]("Spark version")
 
@@ -143,7 +145,9 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
     libraryDependencies ++= {
       val sv = sparkVersion.value
       Seq(
-        "net.snowflake" % "snowflake-jdbc" % "3.28.0",
+        "net.snowflake" % "snowflake-jdbc" % "4.0.2",
+        "com.amazonaws" % "aws-java-sdk-s3" % "1.12.780",
+        "com.microsoft.azure" % "azure-storage" % "8.6.6",
         "org.scalatest" %% "scalatest" % "3.2.19" % Test,
         "org.mockito" % "mockito-core" % "4.11.0" % Test,
         "org.apache.commons" % "commons-lang3" % "3.18.0" % "provided",
@@ -169,6 +173,63 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
           "org.apache.spark" %% "spark-sql-api" % sv % "provided, test"
         ) else Seq.empty
       )
+    },
+
+    dependencyOverrides ++= Seq(
+      "com.fasterxml.jackson.core"   % "jackson-core"          % "2.15.2",
+      "com.fasterxml.jackson.core"   % "jackson-databind"      % "2.15.2",
+      "com.fasterxml.jackson.core"   % "jackson-annotations"   % "2.15.2",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.2"
+    ),
+
+    assembly / assemblyShadeRules := Seq(
+      ShadeRule.rename("com.amazonaws.**"       -> "net.snowflake.spark.shaded.amazonaws.@1").inAll,
+      ShadeRule.rename("com.microsoft.azure.**" -> "net.snowflake.spark.shaded.azure.@1").inAll,
+      ShadeRule.rename("software.amazon.ion.**" -> "net.snowflake.spark.shaded.amazonion.@1").inAll
+    ),
+
+    // Only fold the AWS and Azure SDKs (and their AWS-specific transitives) into
+    // the assembly. Common libraries (jackson, joda-time, httpclient, commons-*,
+    // slf4j) stay unbundled and resolve from the user's Spark/Hadoop classpath.
+    assembly / assemblyExcludedJars := {
+      val cp = (assembly / fullClasspath).value
+      val keepPrefixes = Seq(
+        "aws-java-sdk-", "jmespath-java-", "ion-java-",
+        "azure-storage-", "azure-keyvault-core-"
+      )
+      cp.filter { entry =>
+        val n = entry.data.getName
+        !keepPrefixes.exists(p => n.startsWith(p))
+      }
+    },
+
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "MANIFEST.MF")     => MergeStrategy.discard
+      case PathList("META-INF", xs @ _*) if xs.lastOption.exists(s =>
+            s.endsWith(".SF") || s.endsWith(".DSA") || s.endsWith(".RSA")) =>
+        MergeStrategy.discard
+      case PathList("module-info.class")           => MergeStrategy.discard
+      case PathList(ps @ _*) if ps.lastOption.contains("module-info.class") =>
+        MergeStrategy.discard
+      case other =>
+        val old = (assembly / assemblyMergeStrategy).value
+        old(other)
+    },
+
+    Compile / packageBin := assembly.value,
+
+    pomPostProcess := { (node: XmlNode) =>
+      val rule = new RewriteRule {
+        override def transform(n: XmlNode): XmlNodeSeq = n match {
+          case e: Elem if e.label == "dependency" =>
+            val groupId = (e \ "groupId").text
+            if (groupId == "com.amazonaws" || groupId == "com.microsoft.azure") {
+              XmlNodeSeq.Empty
+            } else e
+          case other => other
+        }
+      }
+      new RuleTransformer(rule).transform(node).head
     },
 
     Compile / scalastyleSources ++= (Compile / unmanagedSourceDirectories).value,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,5 +11,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+
 // for resolving different scala-xml version requirements between sbt-scoverage and scalastyle-sbt-plugin.
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/src/it/scala/net/snowflake/spark/snowflake/ShareConnectionSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/ShareConnectionSuite.scala
@@ -16,7 +16,7 @@
 
 package net.snowflake.spark.snowflake
 
-import net.snowflake.client.jdbc.SnowflakeConnectionV1
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl
 
 import java.util.TimeZone
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME

--- a/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SnowflakeTelemetrySuite.scala
@@ -4,7 +4,7 @@ import java.nio.file.Files
 
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode
-import net.snowflake.client.jdbc.telemetry.Telemetry
+import net.snowflake.client.internal.jdbc.telemetry.Telemetry
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import org.apache.spark.SparkEnv
 import org.apache.spark.ml.linalg.{Vector, Vectors}

--- a/src/it/scala/net/snowflake/spark/snowflake/SparkConnectorContextSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/SparkConnectorContextSuite.scala
@@ -16,7 +16,8 @@
 
 package net.snowflake.spark.snowflake
 
-import net.snowflake.client.jdbc.{SnowflakeResultSet, SnowflakeStatement}
+import net.snowflake.client.api.resultset.SnowflakeResultSet
+import net.snowflake.client.api.statement.SnowflakeStatement
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}

--- a/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/TruncateTableSuite.scala
@@ -1,6 +1,6 @@
 package net.snowflake.spark.snowflake
 
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import net.snowflake.spark.snowflake.test.TestHook
 import net.snowflake.spark.snowflake.test.TestHookFlag.{

--- a/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/io/StageSuite.scala
@@ -17,7 +17,8 @@
 package net.snowflake.spark.snowflake.io
 
 import java.io.File
-import net.snowflake.client.jdbc.{SnowflakeFileTransferMetadataV1, SnowflakeSQLException}
+import net.snowflake.client.api.exception.SnowflakeSQLException
+import net.snowflake.client.internal.jdbc.SnowflakeFileTransferMetadataV1
 import net.snowflake.client.jdbc.internal.apache.commons.io.FileUtils
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}

--- a/src/main/scala/net/snowflake/spark/snowflake/CloudCredentialsUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/CloudCredentialsUtils.scala
@@ -19,13 +19,13 @@ package net.snowflake.spark.snowflake
 
 import java.net.URI
 
-import net.snowflake.client.jdbc.internal.amazonaws.auth.{
+import com.amazonaws.auth.{
   AWSCredentials,
   AWSSessionCredentials,
   BasicAWSCredentials,
   InstanceProfileCredentialsProvider
 }
-import net.snowflake.client.jdbc.internal.microsoft.azure.storage.StorageCredentialsSharedAccessSignature
+import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import scala.language.postfixOps
 import org.apache.hadoop.conf.Configuration

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -20,8 +20,8 @@ package net.snowflake.spark.snowflake
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.{KeyFactory, PrivateKey}
 import java.util.Properties
-import net.snowflake.client.jdbc.internal.amazonaws.auth.{AWSCredentials, BasicSessionCredentials}
-import net.snowflake.client.jdbc.internal.microsoft.azure.storage.StorageCredentialsSharedAccessSignature
+import com.amazonaws.auth.{AWSCredentials, BasicSessionCredentials}
+import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature
 import net.snowflake.spark.snowflake.FSType.FSType
 import org.apache.commons.codec.binary.Base64
 import org.apache.spark.sql.types.{StructField, StructType}

--- a/src/main/scala/net/snowflake/spark/snowflake/ProxyInfo.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/ProxyInfo.scala
@@ -4,9 +4,9 @@ import java.net.{InetSocketAddress, Proxy}
 import java.net.Proxy.Type
 import java.util.Properties
 
-import net.snowflake.client.core.SFSessionProperty
-import net.snowflake.client.jdbc.internal.amazonaws.{ClientConfiguration, Protocol, ProxyAuthenticationMethod}
-import net.snowflake.client.jdbc.internal.microsoft.azure.storage.OperationContext
+import net.snowflake.client.internal.core.SFSessionProperty
+import com.amazonaws.{ClientConfiguration, Protocol, ProxyAuthenticationMethod}
+import com.microsoft.azure.storage.OperationContext
 import scala.collection.JavaConverters._
 
 private[snowflake] class ProxyInfo(proxyProtocol: Option[String],

--- a/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/ServerConnection.scala
@@ -1,7 +1,7 @@
 package net.snowflake.spark.snowflake
 
-import net.snowflake.client.core.{SFBaseSession, SFSession, SFSessionProperty}
-import net.snowflake.client.jdbc.SnowflakeConnectionV1
+import net.snowflake.client.internal.core.{SFBaseSession, SFSession, SFSessionProperty}
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl
 import net.snowflake.spark.snowflake.Parameters.{MergedParameters, PARAM_SF_URL, PARAM_SF_USER}
 import net.snowflake.spark.snowflake.Utils.JDBC_DRIVER
 import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
@@ -300,7 +300,7 @@ private[snowflake] object ServerConnection {
     // use provided JDBC connection
     private val providedConn = mutable.Map[String, Connection]()
     def register(conn: Connection): String = {
-      val sessionId: String = conn.asInstanceOf[SnowflakeConnectionV1].getSessionID
+      val sessionId: String = conn.asInstanceOf[SnowflakeConnectionImpl].getSessionID
       providedConn.put(sessionId, conn)
       sessionId
     }
@@ -317,7 +317,7 @@ private[snowflake] object ServerConnection {
 
     def getParameters(id: String): Map[String, String] =
       providedConn.get(id) match {
-        case Some(sfConn: SnowflakeConnectionV1) =>
+        case Some(sfConn: SnowflakeConnectionImpl) =>
           val map = mutable.Map[String, String]()
           map.put(PARAM_SF_URL, sfConn.getSfSession.getUrl)
           map.put(PARAM_SF_USER, sfConn.getSfSession.getUser)
@@ -344,10 +344,10 @@ private[snowflake] class ServerConnection(val jdbcConnection: Connection, val en
 
   def rollback(): Unit = jdbcConnection.rollback()
 
-  def getSessionID: String = jdbcConnection.asInstanceOf[SnowflakeConnectionV1].getSessionID
+  def getSessionID: String = jdbcConnection.asInstanceOf[SnowflakeConnectionImpl].getSessionID
 
-  def getSfSession: SFSession = jdbcConnection.asInstanceOf[SnowflakeConnectionV1].getSfSession
+  def getSfSession: SFSession = jdbcConnection.asInstanceOf[SnowflakeConnectionImpl].getSfSession
 
   def getSFBaseSession: SFBaseSession =
-    jdbcConnection.asInstanceOf[SnowflakeConnectionV1].getSFBaseSession
+    jdbcConnection.asInstanceOf[SnowflakeConnectionImpl].getSFBaseSession
 }

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -22,10 +22,11 @@ package net.snowflake.spark.snowflake
 import java.sql.{PreparedStatement, ResultSet, ResultSetMetaData, SQLException, Statement}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, ThreadFactory}
-import net.snowflake.client.jdbc.telemetry.{Telemetry, TelemetryClient}
+import net.snowflake.client.internal.jdbc.telemetry.{Telemetry, TelemetryClient}
 import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
-import net.snowflake.client.jdbc.{SnowflakePreparedStatement, SnowflakeResultSet, SnowflakeStatement}
+import net.snowflake.client.api.resultset.SnowflakeResultSet
+import net.snowflake.client.api.statement.{SnowflakePreparedStatement, SnowflakeStatement}
 import net.snowflake.spark.snowflake.io.SnowflakeResultSetRDD
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -31,7 +31,8 @@ import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
 
 import scala.language.postfixOps
 import scala.reflect.ClassTag
-import net.snowflake.client.jdbc.{SnowflakeLoggedFeatureNotSupportedException, SnowflakeResultSet, SnowflakeResultSetSerializable}
+import net.snowflake.client.api.resultset.{SnowflakeResultSet, SnowflakeResultSetSerializable}
+import net.snowflake.client.internal.jdbc.SnowflakeLoggedFeatureNotSupportedException
 import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}
 
 import scala.collection.JavaConverters

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
@@ -2,13 +2,13 @@ package net.snowflake.spark.snowflake
 
 import java.io.{PrintWriter, StringWriter}
 import java.util.regex.Pattern
-import net.snowflake.client.jdbc.SnowflakeSQLException
-import net.snowflake.client.jdbc.telemetry.{Telemetry, TelemetryClient}
+import net.snowflake.client.api.exception.SnowflakeSQLException
+import net.snowflake.client.internal.jdbc.telemetry.{Telemetry, TelemetryClient}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.slf4j.LoggerFactory
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode
-import net.snowflake.client.jdbc.telemetryOOB.{TelemetryEvent, TelemetryService}
+import net.snowflake.client.internal.jdbc.telemetryOOB.{TelemetryEvent, TelemetryService}
 import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
 import net.snowflake.spark.snowflake.TelemetryTypes.TelemetryTypes
 import org.apache.spark.sql.SparkSession

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeWriter.scala
@@ -18,7 +18,7 @@
 package net.snowflake.spark.snowflake
 
 import java.sql.{Date, Timestamp}
-import net.snowflake.client.jdbc.internal.apache.commons.codec.binary.Base64
+import java.util.Base64
 import net.snowflake.spark.snowflake.DefaultJDBCWrapper.{snowflakeStyleSchema, snowflakeStyleString}
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import net.snowflake.spark.snowflake.io.SupportedFormat
@@ -237,7 +237,7 @@ private[snowflake] class SnowflakeWriter(jdbcWrapper: JDBCWrapper) {
           (v: Any) =>
             v match {
               case null => ""
-              case bytes: Array[Byte] => Base64.encodeBase64String(bytes)
+              case bytes: Array[Byte] => Base64.getEncoder.encodeToString(bytes)
             }
         case _ => (input: Any) => input
       }
@@ -300,7 +300,7 @@ private[snowflake] class SnowflakeWriter(jdbcWrapper: JDBCWrapper) {
           (v: Any) =>
             v match {
               case null => ""
-              case bytes: Array[Byte] => Base64.encodeBase64String(bytes)
+              case bytes: Array[Byte] => Base64.getEncoder.encodeToString(bytes)
             }
         case _ =>
           (v: Any) =>

--- a/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Utils.scala
@@ -21,7 +21,8 @@ import java.net.URI
 import java.sql.{Connection, ResultSet}
 import java.util.{Properties, UUID}
 
-import net.snowflake.client.jdbc.{SnowflakeDriver, SnowflakeResultSet, SnowflakeResultSetSerializable}
+import net.snowflake.client.api.driver.SnowflakeDriver
+import net.snowflake.client.api.resultset.{SnowflakeResultSet, SnowflakeResultSetSerializable}
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import org.apache.spark.{SPARK_VERSION, SparkContext, SparkEnv}
 
@@ -30,8 +31,8 @@ import scala.collection.mutable
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.io._
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.model.BucketLifecycleConfiguration
+import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode
 import net.snowflake.spark.snowflake.FSType.FSType
@@ -59,7 +60,7 @@ object Utils {
   /**
     * The certified JDBC version to work with this spark connector version.
     */
-  val CERTIFIED_JDBC_VERSION = "3.28.0"
+  val CERTIFIED_JDBC_VERSION = "4.0.2"
 
   /**
     * Important:
@@ -81,7 +82,7 @@ object Utils {
   private[snowflake] lazy val javaVersion =
     System.getProperty("java.version", "UNKNOWN")
   private[snowflake] lazy val jdbcVersion =
-    SnowflakeDriver.implementVersion
+    SnowflakeDriver.getImplementationVersion()
   private val mapper = new ObjectMapper()
 
   private[snowflake] val JDBC_DRIVER =

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -24,20 +24,20 @@ import java.util.Properties
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 import javax.crypto.{Cipher, CipherInputStream, CipherOutputStream, SecretKey}
 import javax.crypto.spec.{IvParameterSpec, SecretKeySpec}
-import net.snowflake.client.core.{OCSPMode, SFStatement}
-import net.snowflake.client.jdbc.{ErrorCode, MatDesc, SnowflakeFileTransferAgent, SnowflakeFileTransferConfig, SnowflakeFileTransferMetadata, SnowflakeSQLException}
-import net.snowflake.client.jdbc.cloud.storage.StageInfo.StageType
-import net.snowflake.client.jdbc.internal.amazonaws.ClientConfiguration
-import net.snowflake.client.jdbc.internal.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials, BasicSessionCredentials}
-import net.snowflake.client.jdbc.internal.amazonaws.client.builder.AwsClientBuilder
-import net.snowflake.client.jdbc.internal.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.{AmazonS3, AmazonS3Client, AmazonS3ClientBuilder}
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.model._
-import net.snowflake.client.jdbc.internal.amazonaws.util.Base64
+import net.snowflake.client.internal.core.{OCSPMode, SFStatement}
+import net.snowflake.client.api.exception.{ErrorCode, SnowflakeSQLException}
+import net.snowflake.client.internal.jdbc.{MatDesc, SnowflakeFileTransferAgent, SnowflakeFileTransferConfig, SnowflakeFileTransferMetadata}
+import net.snowflake.client.internal.jdbc.cloud.storage.StageInfo.StageType
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials, BasicSessionCredentials}
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.model._
+import java.util.Base64
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
-import net.snowflake.client.jdbc.internal.microsoft.azure.storage.{AccessCondition, OperationContext, StorageCredentialsAnonymous, StorageCredentialsSharedAccessSignature}
-import net.snowflake.client.jdbc.internal.microsoft.azure.storage.blob.{BlobRequestOptions, CloudBlobClient, CloudBlockBlob}
-import net.snowflake.client.jdbc.internal.snowflake.common.core.SqlState
+import com.microsoft.azure.storage.{AccessCondition, OperationContext, StorageCredentialsAnonymous, StorageCredentialsSharedAccessSignature}
+import com.microsoft.azure.storage.blob.{BlobRequestOptions, CloudBlobClient, CloudBlockBlob}
 import net.snowflake.spark.snowflake._
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import net.snowflake.spark.snowflake.io.SupportedFormat.SupportedFormat
@@ -86,7 +86,7 @@ object CloudStorageOperations {
                                             stageType: StageType
                                           ): InputStream = {
 
-    val decodedKey = Base64.decode(masterKey)
+    val decodedKey = Base64.getDecoder.decode(masterKey)
     val (key, iv) =
       stageType match {
         case StageType.S3 =>
@@ -101,14 +101,14 @@ object CloudStorageOperations {
 
     if (key == null || iv == null) {
       throw new SnowflakeSQLException(
-        SqlState.INTERNAL_ERROR,
+        "22000",
         ErrorCode.INTERNAL_ERROR.getMessageCode,
         "File " + "metadata incomplete"
       )
     }
 
-    val keyBytes: Array[Byte] = Base64.decode(key)
-    val ivBytes: Array[Byte] = Base64.decode(iv)
+    val keyBytes: Array[Byte] = Base64.getDecoder.decode(key)
+    val ivBytes: Array[Byte] = Base64.getDecoder.decode(iv)
 
     val queryStageMasterKey: SecretKey =
       new SecretKeySpec(decodedKey, 0, decodedKey.length, AES)
@@ -186,7 +186,7 @@ object CloudStorageOperations {
                                               smkId: String
                                             ): (Cipher, String, String, String) = {
 
-    val decodedKey = Base64.decode(masterKey)
+    val decodedKey = Base64.getDecoder.decode(masterKey)
     val keySize = decodedKey.length
     val fileKeyBytes = new Array[Byte](keySize)
     val fileCipher = Cipher.getInstance(DATA_CIPHER)
@@ -217,8 +217,8 @@ object CloudStorageOperations {
     (
       fileCipher,
       matDesc.toString,
-      Base64.encodeAsString(encKeK: _*),
-      Base64.encodeAsString(ivData: _*)
+      Base64.getEncoder.encodeToString(encKeK),
+      Base64.getEncoder.encodeToString(ivData)
     )
   }
 
@@ -315,7 +315,7 @@ object CloudStorageOperations {
           case Some(creds) =>
             // Extract credentials from temporaryAWSCredentials object
             val token = creds match {
-              case sessionCreds: net.snowflake.client.jdbc.internal.amazonaws.auth.AWSSessionCredentials =>
+              case sessionCreds: com.amazonaws.auth.AWSSessionCredentials =>
                 Some(sessionCreds.getSessionToken)
               case _ => None
             }

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SFInternalStage.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SFInternalStage.scala
@@ -16,10 +16,11 @@
 
 package net.snowflake.spark.snowflake.io
 
-import net.snowflake.client.jdbc.internal.amazonaws.util.Base64
-import net.snowflake.client.core.SFStatement
+import java.util.Base64
+import net.snowflake.client.internal.core.SFStatement
+import net.snowflake.client.internal.jdbc.SnowflakeFileTransferAgent
 import net.snowflake.client.jdbc._
-import net.snowflake.client.jdbc.cloud.storage.StageInfo
+import net.snowflake.client.internal.jdbc.cloud.storage.StageInfo
 import net.snowflake.spark.snowflake._
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 
@@ -133,7 +134,7 @@ private[io] class SFInternalStage(isWrite: Boolean,
   private[io] lazy val masterKey =
     if (encMat != null) encMat.getQueryStageMasterKey else null
   private[io] lazy val decodedKey =
-    if (masterKey != null) Base64.decode(masterKey) else null
+    if (masterKey != null) Base64.getDecoder.decode(masterKey) else null
 
   private[io] lazy val is256Encryption: Boolean = {
     val length = if (decodedKey != null) decodedKey.length * 8 else 128

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -3,7 +3,8 @@ package net.snowflake.spark.snowflake.io
 import java.sql.ResultSet
 import java.util.Properties
 
-import net.snowflake.client.jdbc.{ErrorCode, SnowflakeResultSetSerializable, SnowflakeSQLException}
+import net.snowflake.client.api.exception.{ErrorCode, SnowflakeSQLException}
+import net.snowflake.client.api.resultset.SnowflakeResultSetSerializable
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper
 import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}
 import net.snowflake.spark.snowflake.{

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageReader.scala
@@ -1,6 +1,6 @@
 package net.snowflake.spark.snowflake.io
 
-import net.snowflake.client.jdbc.SnowflakeResultSet
+import net.snowflake.client.api.resultset.SnowflakeResultSet
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode
 import net.snowflake.spark.snowflake.Parameters.MergedParameters

--- a/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/StageWriter.scala
@@ -18,7 +18,7 @@ package net.snowflake.spark.snowflake.io
 import java.sql.ResultSet
 import java.time.LocalDateTime
 import java.util.TimeZone
-import net.snowflake.client.jdbc.SnowflakeResultSet
+import net.snowflake.client.api.resultset.SnowflakeResultSet
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import net.snowflake.spark.snowflake._
 import net.snowflake.spark.snowflake.io.SupportedFormat.SupportedFormat

--- a/src/main/scala/net/snowflake/spark/snowflake/test/TestHook.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/test/TestHook.scala
@@ -1,6 +1,6 @@
 package net.snowflake.spark.snowflake.test
 
-import net.snowflake.client.jdbc.{ErrorCode, SnowflakeSQLException}
+import net.snowflake.client.api.exception.{ErrorCode, SnowflakeSQLException}
 import net.snowflake.spark.snowflake.test.TestHookFlag.TestHookFlag
 import org.slf4j.{Logger, LoggerFactory}
 

--- a/src/test/scala/net/snowflake/spark/snowflake/BaseTest.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/BaseTest.scala
@@ -18,9 +18,9 @@ package net.snowflake.spark.snowflake
 import java.io.File
 import java.net.URI
 
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.AmazonS3Client
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.model.BucketLifecycleConfiguration
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.mapreduce.InputFormat

--- a/src/test/scala/net/snowflake/spark/snowflake/CloudCredentialsUtilsSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/CloudCredentialsUtilsSuite.scala
@@ -17,12 +17,12 @@
 
 package net.snowflake.spark.snowflake
 
-import net.snowflake.client.jdbc.internal.amazonaws.AmazonClientException
-import net.snowflake.client.jdbc.internal.amazonaws.auth.{
+import com.amazonaws.AmazonClientException
+import com.amazonaws.auth.{
   BasicAWSCredentials,
   BasicSessionCredentials
 }
-import net.snowflake.client.jdbc.internal.microsoft.azure.storage.StorageCredentialsSharedAccessSignature
+import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/MiscSuite01.scala
@@ -21,12 +21,12 @@ import java.net.{InetSocketAddress, Proxy}
 import java.security.InvalidKeyException
 import java.util.Properties
 
-import net.snowflake.client.core.SFSessionProperty
-import net.snowflake.client.jdbc.SnowflakeSQLException
-import net.snowflake.client.jdbc.internal.amazonaws.{ClientConfiguration, Protocol}
+import net.snowflake.client.internal.core.SFSessionProperty
+import net.snowflake.client.api.exception.SnowflakeSQLException
+import com.amazonaws.{ClientConfiguration, Protocol}
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode
-import net.snowflake.client.jdbc.internal.microsoft.azure.storage.OperationContext
+import com.microsoft.azure.storage.OperationContext
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.SparkSession
 import org.scalatest.funsuite.AnyFunSuite
@@ -307,7 +307,7 @@ class MiscSuite01 extends AnyFunSuite with Matchers {
     SnowflakeTelemetry.addThrowable(metric,
       new SnowflakeSQLException(queryId, errorMessage, sqlState, errorCode))
     assert(metric.get(TelemetryQueryStatusFields.EXCEPTION_CLASS_NAME).asText()
-      .equals("class net.snowflake.client.jdbc.SnowflakeSQLException"))
+      .equals("class net.snowflake.client.api.exception.SnowflakeSQLException"))
     var expectedMessage = s"SnowflakeSQLException: ErrorCode=$errorCode" +
       s" SQLState=$sqlState QueryId=$queryId"
     assert(metric.get(TelemetryQueryStatusFields.EXCEPTION_MESSAGE)

--- a/src/test/scala/net/snowflake/spark/snowflake/io/S3UploadOutputStreamAbortSuite.scala
+++ b/src/test/scala/net/snowflake/spark/snowflake/io/S3UploadOutputStreamAbortSuite.scala
@@ -15,8 +15,8 @@
  */
 package net.snowflake.spark.snowflake.io
 
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.AbstractAmazonS3
-import net.snowflake.client.jdbc.internal.amazonaws.services.s3.model.{
+import com.amazonaws.services.s3.AbstractAmazonS3
+import com.amazonaws.services.s3.model.{
   AbortMultipartUploadRequest,
   CompleteMultipartUploadRequest,
   CompleteMultipartUploadResult,


### PR DESCRIPTION
Upgrade `snowflake-jdbc` from 3.28.0 to 4.0.2. JDBC 4.x no longer ships shaded AWS / Azure SDKs, so the connector now depends on them directly and relocates them into the released jar via `sbt-assembly`. The user-visible classpath is unchanged — only the JDBC driver upgrade is observable to customers.
This is a re-implementation of #647 on top of current `master` (which has since absorbed cross-build, Spark 4, and other changes).
**This is a BCR**: drops runtime support for JDBC 3.x. 

Co-authored-by: Bing Li <bing.li@snowflake.com>