### PR TITLE
NOSNOW: clean publish staging between Spark version iterations in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -84,6 +84,8 @@ git checkout tags/$GITHUB_TAG_1
 if [ "$PUBLISH" = true ]; then
   for spark_version in $SPARK_VERSIONS; do
     echo "Publishing for Spark $spark_version..."
+    # Clean prior iteration's staging so sonaUpload bundles only the current sparkVersion.
+    rm -rf target/sonatype-staging ~/.ivy2/local/net.snowflake/spark-snowflake*
     sbt -DsparkVersion=$spark_version +publishSigned sonaUpload sonaRelease
   done
 else

--- a/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/CloudStorageOperations.scala
@@ -118,7 +118,7 @@ object CloudStorageOperations {
 
     val fileKeyBytes: Array[Byte] = keyCipher.doFinal(keyBytes)
     val fileKey =
-      new SecretKeySpec(fileKeyBytes, 0, decodedKey.length, AES)
+      new SecretKeySpec(fileKeyBytes, 0, fileKeyBytes.length, AES)
 
     val dataCipher = Cipher.getInstance(DATA_CIPHER)
     val ivy: IvParameterSpec = new IvParameterSpec(ivBytes)


### PR DESCRIPTION
Fixes the Central Portal duplicate-component validation failure that
blocked the spark_4.0 cell of the v3.2.0 release. Without per-iteration
cleanup, sonaUpload bundles previously-released spark_3.5 artifacts
together with the current iteration's spark_4.0 / spark_4.1 artifacts,
which Central Portal rejects as already existing on Maven Central.

Mirrors the existing rm -rf cleanup in the non-publish branch of the
script.
