### PR TITLE
NOSNOW: clean the correct sona staging dir between Spark iterations

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -85,7 +85,7 @@ if [ "$PUBLISH" = true ]; then
   for spark_version in $SPARK_VERSIONS; do
     echo "Publishing for Spark $spark_version..."
     # Clean prior iteration's staging so sonaUpload bundles only the current sparkVersion.
-    rm -rf target/sonatype-staging ~/.ivy2/local/net.snowflake/spark-snowflake*
+    rm -rf target/sona-staging target/sonatype-staging ~/.ivy2/local/net.snowflake/spark-snowflake*
     sbt -DsparkVersion=$spark_version +publishSigned sonaUpload sonaRelease
   done
 else


### PR DESCRIPTION
The previous [PR](https://github.com/snowflakedb/spark-snowflake/pull/658) didn't fully fix the staging cleanup issue. I reproduced the issue locally (a mixed 3.5+4.0 bundle was incorrectly left in staging), and then verified that with the current fix, cleanup is done correctly (only 4.0 is left), which should unblock the jenkins publishing job.